### PR TITLE
add icon to node model and allow it to be set by flag from noop role

### DIFF
--- a/core/barclamps/test.yml
+++ b/core/barclamps/test.yml
@@ -85,6 +85,7 @@ roles:
     flags:
       - implicit
       - milestone
+      - replace_node_icon
     requires:
       - test-server
       - test-library

--- a/core/rails/app/models/barclamp.rb
+++ b/core/rails/app/models/barclamp.rb
@@ -190,6 +190,7 @@ class Barclamp < ActiveRecord::Base
                              conflicts:   role_conflicts,
                              preceeds:    role_preceeds,
                              milestone:   flags.include?('milestone'),
+                             replace_node_icon: flags.include?('replace_node_icon'),
                              library:     flags.include?('library'),
                              implicit:    flags.include?('implicit'),
                              bootstrap:   flags.include?('bootstrap'),

--- a/core/rails/app/models/barclamp_test/jig.rb
+++ b/core/rails/app/models/barclamp_test/jig.rb
@@ -24,6 +24,12 @@ class BarclampTest::Jig < Jig
     raise "Cannot call TestJig::Run on #{nr.name}" unless nr.state == NodeRole::TRANSITION
 
     Node.transaction do
+      # allows a noop role to coerce the icon for a node
+      if nr.role.replace_node_icon
+        n = nr.node
+        n.icon = nr.role.icon
+        n.save!
+      end
       # create tests data
       Attrib.set('random', nr.node, Random.rand(1000000)) rescue nil
       marker = Attrib.get('marker', nr.node) || nr.name rescue nr.name

--- a/core/rails/app/models/jig.rb
+++ b/core/rails/app/models/jig.rb
@@ -123,6 +123,14 @@ class NoopJig < Jig
   end
 
   def run(nr,data)
+    # allows a nooprole to coerce the icon for a node
+    if nr.role.replace_node_icon
+      Node.transaction do
+        n = nr.node
+        n.icon = nr.role.icon
+        n.save!
+      end
+    end
     return true
   end
 

--- a/core/rails/db/migrate/20160914154200_add_nodeicon.rb
+++ b/core/rails/db/migrate/20160914154200_add_nodeicon.rb
@@ -1,0 +1,28 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class AddNodeicon < ActiveRecord::Migration
+
+  def self.up
+    add_column :nodes, :icon, :text, null: false, default: 'check_circle'
+    add_column :roles, :replace_node_icon, :boolean, null: false, default: false
+  end
+
+  def self.down
+   remove_column :nodes, :icon
+   remove_column :roles, :replace_node_icon
+  end
+
+end


### PR DESCRIPTION
This allows users and workloads to set icons for nodes.
the icon only shows up if the node is ready
