### PR TITLE
Due to exponential backoff on container restarts, this can take awhile

### DIFF
--- a/deploy/scripts/wait_for_rebar.sh
+++ b/deploy/scripts/wait_for_rebar.sh
@@ -79,11 +79,11 @@ else
 fi
 
 echo "Waiting on system deployment"
-retry_until 240 \
+retry_until 1200 \
             "Took too long for system deployment to appear" \
             rebar deployments show system || exit 1
 echo "Waiting on system-phantom.internal.local"
-retry_until 240 \
+retry_until 1200 \
             "Took too long for system-phantom.internal.local to be runnable" \
             test_phantom || exit 1
 echo "Waiting for rebar to converge (up to 10 minutes)"

--- a/deploy/tasks/compose.yml
+++ b/deploy/tasks/compose.yml
@@ -169,17 +169,17 @@
   - debug: msg="Expected IP {{dr_external_ip | ipaddr('address')}}"
     when: dr_access_mode == "HOST" and ansible_version is defined and {{ansible_version.full|version_compare('1.9.0', '>=')}}
 
-  - name: HOSTMODE wait until Digital Rebar service is up [1 upto 20 minutes]
-    wait_for: host="{{dr_external_ip | ipaddr('address')}}" port=3000 delay=60 timeout=1200
+  - name: HOSTMODE wait until Digital Rebar service is up [1 upto 40 minutes]
+    wait_for: host="{{dr_external_ip | ipaddr('address')}}" port=3000 delay=60 timeout=2400
     when: dr_access_mode == "HOST" and ansible_version is defined and {{ansible_version.full|version_compare('1.9.0', '>=')}}
 
   - debug: msg="Expected IP {{ansible_default_ipv4.address}}"
     when: dr_access_mode == "FORWARDER" and ansible_version is defined and {{ansible_version.full|version_compare('1.9.0', '>=')}}
 
-  - name: FORWARDER wait until Digital Rebar service is up [1 upto 20 minutes]
-    wait_for: host="{{ansible_default_ipv4.address}}" port=3000 delay=60 timeout=1200
+  - name: FORWARDER wait until Digital Rebar service is up [1 upto 40 minutes]
+    wait_for: host="{{ansible_default_ipv4.address}}" port=3000 delay=60 timeout=2400
     when: dr_access_mode == "FORWARDER" and ansible_version is defined and {{ansible_version.full|version_compare('1.9.0', '>=')}}
 
-  - name: wait for admin convergence
+  - name: wait for admin convergence [1 upto 20 minutes]
     command: "{{home_dir.stdout}}/digitalrebar/deploy/scripts/wait_for_rebar.sh"
 


### PR DESCRIPTION
for rule-engine/rebar-api sync up.  Up the time outs.