### PR TITLE
Create capability groups (preliminary)

### DIFF
--- a/core/rails/app/controllers/capabilities_controller.rb
+++ b/core/rails/app/controllers/capabilities_controller.rb
@@ -49,6 +49,11 @@ class CapabilitiesController < ::ApplicationController
     Capability.transaction do
       @capability = find_key_cap(model, params[:id], cap("UPDATE")).lock!
       simple_update(@capability,%w{description source})
+      # for select cap types, we allow edits
+      if ["dr-groups","user-defined"].include? @capability.source
+        @capability.includes = params[:includes]
+        @capability.save!
+      end
     end
     respond_to do |format|
       format.html { render :action=>:show }

--- a/core/rails/db/seeds.rb
+++ b/core/rails/db/seeds.rb
@@ -159,30 +159,25 @@ ActiveRecord::Base.transaction do
     Capability.find_or_create_by!(name: row[0], description: row[1], source: "provisioner")
   end
 
-  unless Capability.find_by_name("NODE_ALL") begin
-    # CLOUD CAP GROUPS
-    Capability.create! name: "NODE_ALL", description: "All Node Capabilities", source: "dr-groups", 
-      includes: ["NODE_READ", "NODE_PROPOSE", "NODE_DESTROY", "NODE_CREATE", "NODE_RETRY", "NODE_COMMIT", "NODE_POWER", "NODE_SCRUB", "NODE_UPDATE", "NODE_REDEPLOY"]
-    Capability.create! name: "DEPLOYMENT_ALL", description: "All Deployment Capabilities", source: "dr-groups", 
-      includes: ["DEPLOYMENT_READ", "DEPLOYMENT_ANNEAL", "DEPLOYMENT_PROPOSE", "DEPLOYMENT_COMMIT", "DEPLOYMENT_REDEPLOY", "DEPLOYMENT_DESTROY", "DEPLOYMENT_UPDATE", "DEPLOYMENT_CREATE"]
+  # create ALL CAP groups
+  ["NODE_", "DEPLOYMENT_", "NETWORK_", "CAPABILITY_", "TENANT_", "USER_", "EVENT_", "USER_TENANT", "EVENT_", "ATTRIB_", "ROLE_", "BARCLAMP_", 
+            "TEMPLATE_", "BOOTENV_", "SUBNET_", "ZONE_", "MACHINE_"
+  ].each do |block|
+    includes = []
+    Capability.where("name like '#{block}%'").each { |cap| includes << cap.name }
+    Capability.create! name: "#{block}ALL", description: "All #{block} Capabilities", source: "cap-groups", includes: includes rescue nil
   end
 
-  unless Capability.find_by_name("DR_CLOUD_READ") begin
-    # CLOUD CAP GROUPS
-    Capability.create! name: "DR_CLOUD_READ", description: "Digital Rebar Read Only User", source: "dr-groups",
-      includes: ["NODE_READ", "DEPLOYMENT_READ", "GROUP_READ"]
-    Capability.create! name: "DR_CLOUD_USER", description: "Digital Rebar Read Only User", source: "dr-groups",
-      includes: ["DR_CLOUD_READ", "NODE_PROPOSE", "PROVIDER_READ"]
-    Capability.create! name: "DR_CLOUD_ADMIN", description: "Digital Rebar Read Only User", source: "dr-groups",
-      includes: ["DR_CLOUD_USER", "NODE_CREATE", "NODE_DESTROY", "PROVIDER_CREATE"]
-    
-    # GENERAL CAP GROUP
-    Capability.create! name: "DR_READ", description: "Digital Rebar Read Only User", source: "dr-groups",
-      includes: ["NODE_READ", "DEPLOYMENT_READ", "GROUP_READ"]
-    Capability.create! name: "DR_USER", description: "Digital Rebar Read Only User", source: "dr-groups",
-      includes: ["DR_READ", "NODE_DESTROY", "NODE_PROPOSE"]
-    Capability.create! name: "DR_ADMIN", description: "Digital Rebar Read Only User", source: "dr-groups",
-      includes: ["DR_USER", "NODE_CREATE"]
+  # create CAP groups
+  {
+    "CLOUD_READER" => { desc: "Cloud Read Only", includes: ["NODE_READ", "DEPLOYMENT_READ", "GROUP_READ"] },
+    "CLOUD_USER" => { desc: "Cloud", includes: ["CLOUD_READER", "NODE_PROPOSE", "NODE_COMMIT", "NODE_UPDATE", "NODE_CREATE", "NODE_DESTROY"] },
+    "CLOUD_ADMIN" => { desc: "Cloud Admin", includes: ["CLOUD_ADMIN"] },
+    "DR_READER"=> { desc: "General Read Only", includes: ["NODE_READ", "DEPLOYMENT_READ", "GROUP_READ"] },
+    "DR_USER" => { desc: "General", includes: ["DR_READER"] },
+    "DR_ADMIN" => { desc: "General Admin", includes: ["DR_ADMIN", "TEMPLATE_ALL", "BOOTENV_ALL", "MACHINE_ALL", "ZONE_ALL", "SUBENET_ALL", "BARCLAMP__ALL"] },
+  }.each do |name, cap|
+    Capability.create! name: name, description: "Digital Rebar #{cap[:desc]} Users", source: "dr-groups", includes: cap[:includes] rescue nil
   end
 
   Nav.find_or_create_by(item: 'root', name: 'nav.root', description: 'nav.root_description', path: "main_app.root_path", order: 0, development: true)

--- a/core/rails/db/seeds.rb
+++ b/core/rails/db/seeds.rb
@@ -172,10 +172,10 @@ ActiveRecord::Base.transaction do
   {
     "CLOUD_READER" => { desc: "Cloud Read Only", includes: ["NODE_READ", "DEPLOYMENT_READ", "GROUP_READ"] },
     "CLOUD_USER" => { desc: "Cloud", includes: ["CLOUD_READER", "NODE_PROPOSE", "NODE_COMMIT", "NODE_UPDATE", "NODE_CREATE", "NODE_DESTROY"] },
-    "CLOUD_ADMIN" => { desc: "Cloud Admin", includes: ["CLOUD_ADMIN"] },
+    "CLOUD_ADMIN" => { desc: "Cloud Admin", includes: ["CLOUD_USER"] },
     "DR_READER"=> { desc: "General Read Only", includes: ["NODE_READ", "DEPLOYMENT_READ", "GROUP_READ"] },
     "DR_USER" => { desc: "General", includes: ["DR_READER"] },
-    "DR_ADMIN" => { desc: "General Admin", includes: ["DR_ADMIN", "TEMPLATE_ALL", "BOOTENV_ALL", "MACHINE_ALL", "ZONE_ALL", "SUBENET_ALL", "BARCLAMP_ALL"] },
+    "DR_ADMIN" => { desc: "General Admin", includes: ["DR_USER", "TEMPLATE_ALL", "BOOTENV_ALL", "MACHINE_ALL", "ZONE_ALL", "SUBENET_ALL", "BARCLAMP_ALL"] },
   }.each do |name, cap|
     Capability.create! name: name, description: "Digital Rebar #{cap[:desc]} Users", source: "dr-groups", includes: cap[:includes] rescue nil
   end

--- a/core/rails/db/seeds.rb
+++ b/core/rails/db/seeds.rb
@@ -159,6 +159,32 @@ ActiveRecord::Base.transaction do
     Capability.find_or_create_by!(name: row[0], description: row[1], source: "provisioner")
   end
 
+  unless Capability.find_by_name("NODE_ALL") begin
+    # CLOUD CAP GROUPS
+    Capability.create! name: "NODE_ALL", description: "All Node Capabilities", source: "dr-groups", 
+      includes: ["NODE_READ", "NODE_PROPOSE", "NODE_DESTROY", "NODE_CREATE", "NODE_RETRY", "NODE_COMMIT", "NODE_POWER", "NODE_SCRUB", "NODE_UPDATE", "NODE_REDEPLOY"]
+    Capability.create! name: "DEPLOYMENT_ALL", description: "All Deployment Capabilities", source: "dr-groups", 
+      includes: ["DEPLOYMENT_READ", "DEPLOYMENT_ANNEAL", "DEPLOYMENT_PROPOSE", "DEPLOYMENT_COMMIT", "DEPLOYMENT_REDEPLOY", "DEPLOYMENT_DESTROY", "DEPLOYMENT_UPDATE", "DEPLOYMENT_CREATE"]
+  end
+
+  unless Capability.find_by_name("DR_CLOUD_READ") begin
+    # CLOUD CAP GROUPS
+    Capability.create! name: "DR_CLOUD_READ", description: "Digital Rebar Read Only User", source: "dr-groups",
+      includes: ["NODE_READ", "DEPLOYMENT_READ", "GROUP_READ"]
+    Capability.create! name: "DR_CLOUD_USER", description: "Digital Rebar Read Only User", source: "dr-groups",
+      includes: ["DR_CLOUD_READ", "NODE_PROPOSE", "PROVIDER_READ"]
+    Capability.create! name: "DR_CLOUD_ADMIN", description: "Digital Rebar Read Only User", source: "dr-groups",
+      includes: ["DR_CLOUD_USER", "NODE_CREATE", "NODE_DESTROY", "PROVIDER_CREATE"]
+    
+    # GENERAL CAP GROUP
+    Capability.create! name: "DR_READ", description: "Digital Rebar Read Only User", source: "dr-groups",
+      includes: ["NODE_READ", "DEPLOYMENT_READ", "GROUP_READ"]
+    Capability.create! name: "DR_USER", description: "Digital Rebar Read Only User", source: "dr-groups",
+      includes: ["DR_READ", "NODE_DESTROY", "NODE_PROPOSE"]
+    Capability.create! name: "DR_ADMIN", description: "Digital Rebar Read Only User", source: "dr-groups",
+      includes: ["DR_USER", "NODE_CREATE"]
+  end
+
   Nav.find_or_create_by(item: 'root', name: 'nav.root', description: 'nav.root_description', path: "main_app.root_path", order: 0, development: true)
 
   # monitor

--- a/core/rails/db/seeds.rb
+++ b/core/rails/db/seeds.rb
@@ -175,7 +175,7 @@ ActiveRecord::Base.transaction do
     "CLOUD_ADMIN" => { desc: "Cloud Admin", includes: ["CLOUD_ADMIN"] },
     "DR_READER"=> { desc: "General Read Only", includes: ["NODE_READ", "DEPLOYMENT_READ", "GROUP_READ"] },
     "DR_USER" => { desc: "General", includes: ["DR_READER"] },
-    "DR_ADMIN" => { desc: "General Admin", includes: ["DR_ADMIN", "TEMPLATE_ALL", "BOOTENV_ALL", "MACHINE_ALL", "ZONE_ALL", "SUBENET_ALL", "BARCLAMP__ALL"] },
+    "DR_ADMIN" => { desc: "General Admin", includes: ["DR_ADMIN", "TEMPLATE_ALL", "BOOTENV_ALL", "MACHINE_ALL", "ZONE_ALL", "SUBENET_ALL", "BARCLAMP_ALL"] },
   }.each do |name, cap|
     Capability.create! name: name, description: "Digital Rebar #{cap[:desc]} Users", source: "dr-groups", includes: cap[:includes] rescue nil
   end


### PR DESCRIPTION
This patch creates two new types of capabilities:
1) *_ALL groups that are made automatically from the root capabilities
2) DR_ groups that are designed for specific use cases.  These are preliminary and will be updated over the next few weeks as we tune the exact permissions.

Also, the controller had to be updated so that dr-groups could be edited.

There is a matching change in the UX to expose these groups.