### PR TITLE
Update IPMI handling to allow not configuring its network parameters.

### DIFF
--- a/core/barclamps/ipmi.yml
+++ b/core/barclamps/ipmi.yml
@@ -339,6 +339,12 @@ roles:
         schema:
           type: str
           required: true
+      - name: ipmi-configure-networking
+        description: "Whether to configure IPMI networking or leave it alone"
+        map: 'ipmi/configure_networking'
+        default: true
+        schema:
+          type: bool
       - name: ipmi-use-dhcp
         description: "Whether the IPMI controller should get its address via DHCP"
         map: 'ipmi/use_dhcp'
@@ -352,6 +358,9 @@ roles:
         description: 'Messages from configuring IPMI on the system'
         map: 'rebar_wall/status/ipmi/messages'
         default: []
+      - name: ipmi-address
+        description: "The address of the IPMI controller as detected at the end of configuration"
+        map: 'rebar_wall/ipmi/laninfo/ipaddr'
     flags:
       - implicit
 

--- a/core/rails/app/models/barclamp_ipmi/configure.rb
+++ b/core/rails/app/models/barclamp_ipmi/configure.rb
@@ -17,6 +17,7 @@ class BarclampIpmi::Configure < Role
 
   def sysdata(nr)
     na = NetworkAllocation.node_cat(nr.node, "bmc").first
+    return Hash.new unless na
     endpoint = na.address.to_s
     router = na.network.network_router ? na.network.network_router.address.to_s : "0.0.0.0/0"
     r = na.network_range
@@ -38,7 +39,7 @@ class BarclampIpmi::Configure < Role
   def on_active(nr)
     username = Attrib.get('ipmi-username',nr.node)
     authenticator = Attrib.get('ipmi-password',nr.node)
-    endpoint = NetworkAllocation.node_cat(nr.node, "bmc").first.address.addr
+    endpoint = Attrib.get('ipmi-address',nr)
 
     unless nr.node.hammers.find_by(type: "BarclampIpmi::IpmiHammer")
       # We must have a configured IPMI controller to operate.

--- a/core/rails/app/models/barclamp_ipmi/discover.rb
+++ b/core/rails/app/models/barclamp_ipmi/discover.rb
@@ -23,21 +23,6 @@ class BarclampIpmi::Discover < Role
       return
     end
 
-    # If we do not have a BMC network defined, we cannot continue.
-    # lookup up a BMC network-based upon the category/group of the admin network.
-    group_name = 'default'
-    NetworkAllocation.node(nr.node).each do |na|
-      if na.network.category == 'admin'
-        group_name = na.network.group
-        break
-      end
-    end
-    bmcnet = Network.find_by(category: "bmc", group: group_name)
-    unless bmcnet
-      Rails.logger.info("No BMC network created for #{group_name}.")
-      return
-    end
-
     # If the detected IPMI controller needs any quirks, make sure they are added
     # to the node's quirklist
     quirklist = []
@@ -53,29 +38,60 @@ class BarclampIpmi::Discover < Role
     Rails.logger.info("IPMI: #{nr.node.name} using #{quirkset} quirks.")
     nr.node.merge_quirks(quirklist)
 
-    # All BMCs should get addresses from the host range.
-    bmcrange = NetworkRange.find_by!(network_id: bmcnet.id, name: "host")
-    # If we have already allocated an IP address for this BMC, we are done.
-    unless NetworkAllocation.find_by(node_id: nr.node.id, network_range_id: bmcrange.id)
-      Rails.logger.info("No address allocated for the BMC on #{nr.node.name}")
-      addr = nr.wall["rebar_wall"]["ipmi"]["laninfo"]["ipaddr"]
-      mask = nr.wall["rebar_wall"]["ipmi"]["laninfo"]["netmask"]
-      suggested_addr = IP.coerce("#{addr}/#{mask}")
-      address = bmcrange.allocate(nr.node,suggested_addr)
-      # Once we have an address allocated, we will have a noderole created
-      # for this node for the network-bmc role.
-      # Commit it.
-      Rails.logger.info("BMC address #{address.address.to_s} allocated for #{nr.node.name}")
-      nr.node.node_roles.find_by!(role_id: bmcnet.role.id).commit!
-    end
-    # Now that we have the appropriate network information, we need to bind
-    # the ipmi-configure role to this node.
     icr_role = Role.find_by!(name: 'ipmi-configure')
-    unless nr.node.node_roles.find_by(role_id: icr_role.id)
+    ipmi_config = nr.node.node_roles.find_by(role_id: icr_role.id)
+    do_commit = false
+    unless ipmi_config
       Rails.logger.info("Adding ipmi-configure role to #{nr.node.name}")
       # Force the config role into the same deployment as the discover role
       ipmi_config = icr_role.add_to_node_in_deployment(nr.node, nr.deployment)
-      ipmi_config.commit!
+      do_commit = true
     end
+
+    # If we do not have a BMC network defined, we cannot continue.
+    # lookup up a BMC network-based upon the category/group of the admin network.
+    netgroup = nil
+    NetworkAllocation.node(nr.node).each do |na|
+      if na.network.category == 'admin'
+        netgroup = na.network.group
+        break
+      end
+    end
+
+    bmcnet = netgroup ? Network.find_by(category: "bmc", group: netgroup) : nil
+    if !bmcnet
+      if Attrib.get('ipmi-configure-networking',ipmi_config)
+        Attrib.set('ipmi-configure-networking',ipmi_config, false)
+        do_commit = true
+      end
+    else
+      unless Attrib.get('ipmi-configure-networking',ipmi_config) 
+        Attrib.set('ipmi-configure-networking',ipmi_config, true)
+        do_commit = true
+      end
+      if bmcnet.conduit == "bmc"
+        # All BMCs should get addresses from the host range.
+        bmcrange = NetworkRange.find_by!(network_id: bmcnet.id, name: "host")
+        # If we have already allocated an IP address for this BMC, we are done.
+        unless NetworkAllocation.find_by(node_id: nr.node.id, network_range_id: bmcrange.id)
+          Rails.logger.info("No address allocated for the BMC on #{nr.node.name}")
+          addr = nr.wall["rebar_wall"]["ipmi"]["laninfo"]["ipaddr"]
+          mask = nr.wall["rebar_wall"]["ipmi"]["laninfo"]["netmask"]
+          suggested_addr = IP.coerce("#{addr}/#{mask}")
+          address = bmcrange.allocate(nr.node,suggested_addr)
+          # Once we have an address allocated, we will have a noderole created
+          # for this node for the network-bmc role.
+          # Commit it.
+          Rails.logger.info("BMC address #{address.address.to_s} allocated for #{nr.node.name}")
+          nr.node.node_roles.find_by!(role_id: bmcnet.role.id).commit!
+        end
+      elsif bmcnet.conduit == "dhcp"
+        unless Attrib.get('ipmi-use-dhcp',ipmi_config)
+          Attrib.set('ipmi-use-dhcp',ipmi_config, true)
+          do_commit = true
+        end
+      end
+    end
+    ipmi_config.commit! if do_commit
   end
 end


### PR DESCRIPTION
This lets the IPMI handling code configure everything but the network
when DigitalRebar is not responsible for handling the network
configuration of the host system, and handles configuring the BMC to use
DHCP if the BMC network for the node has a DHCP conduit definition.