### PR TITLE
improve regex test for IDs so that they can start with numbers

### DIFF
--- a/core/rails/lib/api_helper.rb
+++ b/core/rails/lib/api_helper.rb
@@ -154,7 +154,7 @@ module ApiHelper
 
     # Helper to determine if a given key is an ActiveRecord DB ID
     def db_id?(key)
-      key.is_a?(Fixnum) or key.is_a?(Integer) or key =~ /^[0-9]+$/
+      key.is_a?(Fixnum) or key.is_a?(Integer) or key =~ /^[^a-zA-Z]+$/
     end
   end
 


### PR DESCRIPTION
this test was overly restrictive once we'd added the integer test
non-ID lookup names just need to be mixed number & letter, this test works for that.