### PR TITLE
Fixes the AWS subnet create (was not actually VPC!)

### DIFF
--- a/containers/cloudwrap/cloudwrap/common.rb
+++ b/containers/cloudwrap/cloudwrap/common.rb
@@ -211,7 +211,10 @@ def get_endpoint(ep)
   return FakeDriver.new(ep) if ep['debug']
 
   case ep['provider']
-  when 'AWS' then Fog::Compute.new(fix_hash(ep))
+  when 'AWS' then
+    eph = fix_hash(ep)
+    eph.delete(:subnet_id) if eph[:subnet_id]
+    Fog::Compute.new(eph)
   when 'Google'
     unless ep['google_json_key']
       log("Google requires the JSON authentication token at google_json_key")

--- a/containers/cloudwrap/cloudwrap/waiter.rb
+++ b/containers/cloudwrap/cloudwrap/waiter.rb
@@ -38,6 +38,7 @@ loop do
     servers.each do |key, val|
       rebar_id = val[0]
       cloudwrap_device_id = server = val[1]
+      next unless server
       ep = val[2]
       endpoint = val[3]
 
@@ -56,7 +57,7 @@ loop do
       # State good?
       case endpoint['provider']
       when 'AWS', 'Google'
-        log "` #{server.id}" rescue log "no server id"
+        log "checking state of ` #{server.id}" rescue log "no server id"
         unless server.ready?
           log "Server #{server.id} not ready, skipping"
           next

--- a/core/rails/app/models/aws_provider.rb
+++ b/core/rails/app/models/aws_provider.rb
@@ -51,11 +51,11 @@ class AwsProvider < CloudProvider
     		length: 30,
     		name: I18n.t('region', scope: "providers.show.aws" )
   		},
-      vpc_id: {
+      subnet_id: {
         type: "text",
         default: "!default",
         length: 30,
-        name: I18n.t('vpc_id', scope: "providers.show.aws" )
+        name: I18n.t('subnet_id', scope: "providers.show.aws" )
       },
       'provider-create-hint' => {
         type: "json_key",

--- a/core/rails/config/locales/rebar/en.yml
+++ b/core/rails/config/locales/rebar/en.yml
@@ -487,7 +487,7 @@ en:
         access_key_id: "Access Key"
         secret_access_key: "Secret"
         region: "Region"
-        vpc_id: "VPC ID"
+        subnet_id: "Subnet ID"
       packet:
         token: "Token"
         id: "ID"


### PR DESCRIPTION
Fog does NOT use VPC when creating VMs, you must supply subnet_id instead.

This changes the vpc_id in the AWS provider to use subnet_id instead.  
Tested this and it works.

Attention @galthaus 