### PR TITLE
allow deployment batch to add ssh keys

### DIFF
--- a/containers/cloudwrap/cloudwrap/common.rb
+++ b/containers/cloudwrap/cloudwrap/common.rb
@@ -221,6 +221,7 @@ def get_endpoint(ep)
       raise "Cannot authenticate Google endpoint"
     end
     res = fix_hash(ep)
+    res.delete(:'provider-create-hint') if res[:'provider-create-hint']
     res[:google_json_key_string] = JSON.generate(res.delete(:google_json_key))
     Fog::Compute.new(res)
   when 'OpenStack' then nil


### PR DESCRIPTION
When creating a cloud workload, users want to be able to add their keys at the deployment.

This is needed for UX wizard changes in process.