### PR TITLE
If we find a network break out of all loops so that we don't

### DIFF
--- a/core/rails/app/models/network.rb
+++ b/core/rails/app/models/network.rb
@@ -59,6 +59,7 @@ class Network < ActiveRecord::Base
         net = n 
         break
       end
+      break if net
     end
     return net if found_range && net.ranges.exists?(allow_bound_leases: true)
     nil


### PR DESCRIPTION
get the answer wrong if we have multiple admin networks.

lookup_network would not match when multiple networks specified.