### PR TITLE
During node_role create cohort wasn't getting set unless the role

### DIFF
--- a/core/rails/app/models/barclamp.rb
+++ b/core/rails/app/models/barclamp.rb
@@ -266,6 +266,11 @@ class Barclamp < ActiveRecord::Base
           end
         end if r && role['events']
       end if bc['roles']
+      # We updated roles and for some reason, the links don't get recursed properly through normal adds.
+      # So, loop all roles and update cohorts.
+      Role.all.each do |r|
+        r.update_cohort
+      end if bc['roles']
       bc['attribs'].each do |attrib|
         Rails.logger.info("Importing attrib #{attrib['name']} for barclamp #{barclamp.name}")
         attrib_type_candidates = []


### PR DESCRIPTION
was a member of a cluster.  One problem is that parent test vs
current cohort value was < and not <=.  We always want the new
node role's cohort to be at least one more that all of its parents.

This also updates the cohort on preceed additions to the graph.
If the new role is a parent to roles (because of preceeds), then
the cohort of the children need to be updated.
If the new role is a child a preceeds parent, then we make sure the
new cohort value for the new child is larger than the parent.

This seems to take care of most of the delete, remove, reset issues
I was seeing.  I'm not sure when this broke.

I've also update delete to only test for hard_children to match the rest of the delete children tests.

I've also added a update to role cohorts after barclamp import.  This seems to address some UI visualization as well