### PR TITLE
Add profile support to Rebar

### DIFF
--- a/core/rails/app/controllers/nodes_controller.rb
+++ b/core/rails/app/controllers/nodes_controller.rb
@@ -232,6 +232,7 @@ class NodesController < ApplicationController
       params.require(:provider_id)
       params[:tenant_id] ||= @current_user.current_tenant_id
       params[:variant] ||= provider.variant_default
+      params[:profiles] ||= []
       validate_create(params[:tenant_id])
       hints = params[:hints] || {}
       Rails.logger.info("Node create params: #{params.inspect}")
@@ -248,7 +249,8 @@ class NodesController < ApplicationController
                                          :bootenv,
                                          :variant,
                                          :arch,
-                                         :os_family))
+                                         :os_family,
+                                         :profiles))
       # Keep suport for mac and ip hints in short form around for legacy Sledgehammer purposes
       # This kinda-sorta bypasses network cap checking, but it is just too useful.
       default_net = Network.lookup_network(params[:ip]) if params[:ip]
@@ -273,7 +275,7 @@ class NodesController < ApplicationController
       @node = find_key_cap(model,params[:id],cap("UPDATE")).lock!
       ## Add better handling of deployment and tenant changing
       if request.patch?
-        patch(@node,%w{name description target_role_id deployment_id allocated available alive bootenv tenant_id})
+        patch(@node,%w{name description target_role_id deployment_id allocated available alive bootenv tenant_id profiles})
       else
         params[:node_deployment].each { |k,v| params[k] = v } if params.has_key? :node_deployment
         params[:deployment_id] = Deployment.find_key(params[:deployment]).id if params.has_key? :deployment
@@ -289,7 +291,8 @@ class NodesController < ApplicationController
                                                :allocated,
                                                :available,
                                                :alive,
-                                               :bootenv))
+                                               :bootenv,
+                                               :profiles))
       end
       validate_update_for(@node)
     end

--- a/core/rails/app/controllers/profiles_controller.rb
+++ b/core/rails/app/controllers/profiles_controller.rb
@@ -1,0 +1,65 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+class ProfilesController < ApplicationController
+  self.model = Profile
+  self.cap_base = "PROFILE"
+
+  def index
+    @profiles = model.order('name')
+    respond_to do |format|
+      format.html { } # show.html.erb
+      format.json { render api_index model, @profiles }
+    end
+  end
+
+  def show
+    @profile = model.find_key params[:id]
+    respond_to do |format|
+      format.html {  }
+      format.json { render api_show @profile }
+    end
+  end
+
+  def update
+    Profile.transaction do
+      @profile= find_key_cap(model,params[:id],cap("UPDATE")).lock!
+      simple_update(@profile,%w{values tenant_id})
+    end
+    render api_show @profile
+  end
+
+  def create
+    params.require(:name)
+    params.require(:values)
+    params[:tenant_id] ||= @current_user.current_tenant_id
+    Profile.transaction do
+      validate_create(params[:tenant_id])
+      @profile = Profile.create!(name: params[:name],
+				 tenant_id: params[:tenant_id],
+                                 values: params[:values])
+    end
+    render api_show @profile
+  end
+
+  def destroy
+    model.transaction do
+      @es = find_key_cap(model, params[:id],cap("DESTROY"))
+      @es.destroy
+    end
+    render api_delete @es
+  end
+  
+end

--- a/core/rails/app/models/attrib.rb
+++ b/core/rails/app/models/attrib.rb
@@ -102,7 +102,7 @@ class Attrib < ActiveRecord::Base
             case source
             when :note then from.notes
             when :proposed,:committed,:hint,:user then from.hint
-            when :all then from.discovery.deep_merge(from.hint)
+            when :all then from.discovery.deep_merge(from.from_profiles).deep_merge(from.hint)
             else from.discovery
             end
           when from.is_a?(DeploymentRole)

--- a/core/rails/app/models/node_role.rb
+++ b/core/rails/app/models/node_role.rb
@@ -461,6 +461,7 @@ class NodeRole < ActiveRecord::Base
   def all_my_data
     res = {}
     res.deep_merge!(wall)
+    res.deep_merge!(node.from_profiles)
     res.deep_merge!(sysdata)
     res.deep_merge!(data)
     res
@@ -473,6 +474,7 @@ class NodeRole < ActiveRecord::Base
   def all_committed_data
     res = deployment_role.all_committed_data
     res.deep_merge!(wall)
+    res.deep_merge!(node.from_profiles)
     res.deep_merge!(sysdata)
     res.deep_merge!(committed_data)
     res

--- a/core/rails/app/models/profile.rb
+++ b/core/rails/app/models/profile.rb
@@ -1,0 +1,41 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Profile < ActiveRecord::Base
+
+  belongs_to :tenant
+
+  validate  :check_sanity
+
+  private
+
+  def check_sanity
+    errors.add(:values, "values must be a JSON object") unless values.is_a?(Hash)
+    values.each do |k,v|
+      attrib = Attrib.find_by(name: k)
+      errors.add(:values, "No such attrib '#{k}', cannot be used in a profile") unless attrib
+      if attrib
+        errors.add(:values, "Attrib '#{k}' is not writable, cannot be set in a profile") unless attrib.writable
+        begin
+          attrib.kwalify_validate(v)
+        rescue Attrib::AttribValidationFailed => e
+          errors.add(:values, "provided value for '#{k}' fails schema validation: #{e.to_s}, cannot be used in a profile")
+        end
+      end
+    end
+  end
+
+end
+

--- a/core/rails/app/models/run.rb
+++ b/core/rails/app/models/run.rb
@@ -92,7 +92,7 @@ class NodeRoleRun < Que::Job
       # Extract any new desired node attribs from the returned wall info
       nr.barclamp.attribs.where(role_id: nil).each do |a|
         val = a.simple_get(nr)
-        next if val.nil?
+        next if val.nil? || a.simple_get(nr.node) == val
         a.set(nr.node,val)
       end
       # Handle updating our global idea about reservations if our wall has any.

--- a/core/rails/config/routes.rb
+++ b/core/rails/config/routes.rb
@@ -313,6 +313,7 @@ Rebar::Application.routes.draw do
             get :children
             resources :attribs
           end
+          resources :profiles
           resources :roles do
             collection do
               get 'sample'

--- a/core/rails/db/migrate/20161021090000_add_profiles.rb
+++ b/core/rails/db/migrate/20161021090000_add_profiles.rb
@@ -1,0 +1,34 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class AddProfiles < ActiveRecord::Migration
+
+  def self.up
+    create_table :profiles do |t|
+      t.uuid     :uuid, null: false, unique: true, default: 'gen_random_uuid()'
+      t.text     :name, null: false, unique: true
+      t.belongs_to :tenant
+      t.jsonb    :values, null: false, default: { expr: "'{}'::jsonb" }
+      t.timestamps
+    end
+
+    add_column :nodes, :profiles, :text, array: true, null: false, default: { expr: "ARRAY[]::text[]" }
+  end
+
+  def self.down
+    remove_column :nodes, :profiles
+  end
+  
+end

--- a/core/rails/db/seeds.rb
+++ b/core/rails/db/seeds.rb
@@ -120,7 +120,12 @@ ActiveRecord::Base.transaction do
    [ "BARCLAMP_CREATE",      "Create Barclamp" ],
    [ "BARCLAMP_READ",        "Read Barclamp" ],
    [ "BARCLAMP_UPDATE",      "Update Barclamp" ],
-   [ "BARCLAMP_DESTROY",     "Destroy Barclamp" ]
+   [ "BARCLAMP_DESTROY",     "Destroy Barclamp" ],
+
+   [ "PROFILE_CREATE",      "Create Profile" ],
+   [ "PROFILE_READ",        "Read Profile" ],
+   [ "PROFILE_UPDATE",      "Update Profile" ],
+   [ "PROFILE_DESTROY",     "Destroy Profile" ]
   ].each do |row|
     Capability.find_or_create_by!(name: row[0], description: row[1], source: "rebar-api")
   end

--- a/go/rebar-api/api/profile.go
+++ b/go/rebar-api/api/profile.go
@@ -1,0 +1,11 @@
+package api
+
+import "github.com/digitalrebar/digitalrebar/go/rebar-api/datatypes"
+
+// Node wraps datatypes.Node to provide the client API.
+type Profile struct {
+	datatypes.Profile
+	Timestamps
+	apiHelper
+	rebarSrc
+}

--- a/go/rebar-api/datatypes/node.go
+++ b/go/rebar-api/datatypes/node.go
@@ -41,8 +41,9 @@ type Node struct {
 	// "linux", "freebsd", "windows", etc.
 	OsFamily string `json:"os_family"`
 	// The ID of the provider that is responsible for node provisioning.
-	ProviderID int64 `json:"provider_id"`
-	TenantID   int64 `json:"tenant_id,omitempty"`
+	ProviderID int64    `json:"provider_id"`
+	TenantID   int64    `json:"tenant_id,omitempty"`
+	Profiles   []string `json:"profiles"`
 }
 
 func (o *Node) ApiName() string {

--- a/go/rebar-api/datatypes/profile.go
+++ b/go/rebar-api/datatypes/profile.go
@@ -1,0 +1,11 @@
+package datatypes
+
+type Profile struct {
+	NameID
+	TenantID int64                  `json:"tenant_id,omitempty"`
+	Values   map[string]interface{} `json:"values"`
+}
+
+func (o *Profile) ApiName() string {
+	return "profiles"
+}

--- a/go/rebar-api/rebar/profile.go
+++ b/go/rebar-api/rebar/profile.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/digitalrebar/digitalrebar/go/rebar-api/api"
+
+func init() {
+	maker := func() api.Crudder { return &api.Profile{} }
+	singularName := "profile"
+	app.AddCommand(makeCommandTree(singularName, maker))
+}


### PR DESCRIPTION
This adds profiles as new top-level constructs in Digital Rebar.

A profile is a named mapping of attrib names to default values for those
attribs.  Unless overridden by the user (by setting attribs via the UI,
API, or CLI), attribs in a profile will take precedence over default
attribs from roles and deployment roles.

Nodes have been updated to contain a new top-level field called
'profiles', which should contain a list of profiles that apply to the
node.  Profiles apply to the node from the last to the first in the list
-- attrib values defined in a profile towards the fromt of the list get
merged in with attrib values from later in the list.  The logic is
similar to how attribs get smashed together -- the default provide the
basics, which the deploymentroles/noderoles/nodes can override, with the
most specific ones taking precendce over the less specific ones.