### PR TITLE
include time field to help track root rotation

### DIFF
--- a/core/barclamps/certexample.yml
+++ b/core/barclamps/certexample.yml
@@ -28,11 +28,19 @@ roles:
     jig: role-provided
     type: "BarclampCluster::MakeCa"
     icon: account_balance
+    flags:
+      - service
     attribs:
       - name: example-ca-label
         description: "Label of the root CA"
         default: "example"
         map: 'cert/label'
+        schema:
+          type: str
+      - name: example-ca-time
+        description: "Generation Time of the root CA"
+        default: "1970-01-01 00:00:00 -0000"
+        map: 'cert/time'
         schema:
           type: str
   - name: example-ca-install-root
@@ -45,6 +53,7 @@ roles:
       - milestone
     wants-attribs:
       - example-ca-label
+      - example-ca-time
     icon: stars
     attribs:
       - name: example-root-file
@@ -70,6 +79,7 @@ roles:
       - milestone
     wants-attribs:
       - example-ca-label
+      - example-ca-time
     icon: enhanced_encryption
     attribs:
       - name: example-cert-file

--- a/core/rails/app/models/barclamp_cluster/make_ca.rb
+++ b/core/rails/app/models/barclamp_cluster/make_ca.rb
@@ -36,6 +36,16 @@ class BarclampCluster::MakeCa < LocalRole
     if !status.success?
       raise "Error: #{out}\n#{err}\n"
     end
+    runlog << "Success\n#{out}Save Generated Date:"
+    attribname = "#{nr.role.name}-time"
+    begin
+      # add the time to the node role
+      gendate = Time.now.to_s
+      Attrib.set(attribname, nr, gendate)
+      runlog << "Generated at `#{gendate}`.\n"
+    rescue
+      runlog << "NOTE: No `#{attribname}` attribute for #{nr.name}, not saving file time value.\nRUNLOG:\n#{runlog}\n"
+    end
     runlog << "Success\n#{out}"
     nr.runlog = runlog.join("")
     nr.save!


### PR DESCRIPTION
since the root file label/name does not change, the system does not easily detect rotation.  
this adds an optional time field so that we can track rotations downstream.