### PR TITLE
Fixup the provisioner and the windows 2012r2 helper scripts.

### DIFF
--- a/containers/provisioner/explode_iso.sh
+++ b/containers/provisioner/explode_iso.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-echo "Explode iso $1 $2 $3"
+echo "Explode iso $1 $2 $3 $4"
 
 rhelish_re='^(redhat|centos|fedora)'
 
-os_name=$1
-iso=$2
-os_install_dir=$3
+os_name="$1"
+iso="$2"
+os_install_dir="$3"
+expected_sha="$4"
 
 echo "Extracting $iso for $os_name"
 [[ -d "${os_install_dir}.extracting" ]] && rm -rf "${os_install_dir}.extracting"
@@ -61,9 +62,10 @@ if [[ $os_name =~ $rhelish_re ]]; then
         createrepo -g "${groups[-1]}" .
     )
 fi
-touch "${os_install_dir}.extracting/.${os_name}.rebar_canary"
-[[ -d "${os_install_dir}" ]] && rm -rf "${os_install_dir}"
+printf '%s' "$expected_sha" > "${os_install_dir}.extracting/.${os_name}.rebar_canary"
+[[ -d "${os_install_dir}" ]] && mv "${os_install_dir}" "${os_install_dir}.deleting"
 mv "${os_install_dir}.extracting" "${os_install_dir}"
+rm -rf "${os_install_dir}.deleting"
 
 if which selinuxenabled && selinuxenabled; then
     restorecon -R -F /tftpboot

--- a/tools/windows/2012r2/update-bootenv.ps1
+++ b/tools/windows/2012r2/update-bootenv.ps1
@@ -1,0 +1,43 @@
+﻿# -*- powershell -*-
+# To run this script:
+# powershell -executionpolicy bypass -file build-2012r2-iso.ps1  [Your Windows .iso name] [New Windows .iso name]
+#
+#
+param(
+    [Cmdletbinding(PositionalBinding = $false)]
+    [string]$bootenv_name,
+    [string]$destisoname
+)
+
+# Calculate the SHA256sum of the generated ISO.
+Write-Host "Calculating SHA256 of ${destisoname}"
+$hash = Get-Filehash -Algorithm SHA256 -Path $destisoname
+$bootenv = (& .\rebar.exe provisioner bootenvs show $bootenv_name) |out-string |convertfrom-json
+
+if (-not $bootenv -or -not $bootenv.OS.IsoSha256) {
+    write-error "Unable to fetch boot environment for ${bootenv_name}."
+    exit 1
+}
+
+if ($bootenv.OS.IsoSha256 -eq $hash.hash.ToLower()) {
+     write-host "SHA256 unchanged, exiting early."
+     exit 0
+}
+
+write-host "Uploading ${destisoname} to Rebar"
+& .\rebar.exe provisioner isos upload $destisoname as $bootenv.OS.IsoFile
+if ($LASTEXITCODE -ne 0) {
+    write-error "Failed to upload ISO"
+    exit 1
+}
+
+$hashVal = $hash.hash.ToLower()
+write-host "Updating ${bootenv_name} ISO SHA256 to ${hashVal}"
+@"
+{ "OS": {"IsoSha256": "${hashVal}"}}
+"@ | & .\rebar.exe provisioner bootenvs update $bootenv_name -
+
+if ($LASTEXITCODE -ne 0) {
+    write-error "Failed to update ${bootenv_name}"
+    exit 1
+}


### PR DESCRIPTION
Allow the provisioner to actually re-expand ISO files when a bootenv
update requires it, and update the windows powershell helper scripts
to generate more correct ISO images and upload them while updating the
appropriate boot environment