### PR TITLE
Make sure that the hardware roles are on the system deployment.

### DIFF
--- a/core/rails/app/controllers/deployments_controller.rb
+++ b/core/rails/app/controllers/deployments_controller.rb
@@ -83,7 +83,7 @@ class DeploymentsController < ApplicationController
   def update
     Deployment.transaction do
       @deployment = find_key_cap(model,params[:id],cap("UPDATE")).lock!
-      simple_update(@deployment,%w{name description tenant_id})
+      simple_update(@deployment,%w{name description tenant_id}, %w{state})
     end
     respond_to do |format|
       format.html { redirect_to deployment_path(@deployment.id) }
@@ -94,7 +94,7 @@ class DeploymentsController < ApplicationController
   def destroy
     model.transaction do
       @deployment = find_key_cap(model, params[:id], cap("DESTROY"))
-      if @deployment.system? # "cannot destroy system deployments" 
+      if @deployment.system? # "cannot destroy system deployments"
         api_not_supported("delete", @deployments)
       else
         @deployment.destroy
@@ -333,7 +333,7 @@ class DeploymentsController < ApplicationController
 
     # assign nodes roles to deployment (cannot be in the top transaction)
     #
-    # Roles should be applied in role_apply_order and then whatever is left in cohort order 
+    # Roles should be applied in role_apply_order and then whatever is left in cohort order
     # (for lack of anything else)
     rao = params["role_apply_order"] || []
     rkeys = roles.keys

--- a/deploy/compose/config-dir/api/config/deployments/system-hw-roles.json
+++ b/deploy/compose/config-dir/api/config/deployments/system-hw-roles.json
@@ -1,0 +1,11 @@
+{
+  "deployment": {
+    "name": "system"
+  },
+  "roles": [
+    "ipmi-flash",
+    "bios-flash",
+    "bios-discover"
+  ],
+  "attributes": []
+}


### PR DESCRIPTION
This will allow for profiles to override the values and allow
for persistant changes to defaults.

Create a workaround for the overloaded state variable in
deployments.  Patch operations would fail for all deployment
updates.  This removes state from the updatable variables.
USE COMMIT OR PROPOSE for those actions.