### PR TITLE
Fix order of args to rev_lt for IPMI and BIOS flash scripts

### DIFF
--- a/core/script/roles/bios-flash/01-flash.sh
+++ b/core/script/roles/bios-flash/01-flash.sh
@@ -39,7 +39,7 @@ while read -r entry; do
             bios-version|bios-revision)
                 printf "Testing firmware version '%s' against '%s'\n" "$v" "$val"
                 version=$val
-                if ! rev_lt "$val" "${VALUES[$v]}"; then
+                if ! rev_lt "${VALUES[$v]}" "$val"; then
                     match=false
                 fi;;
             *)

--- a/core/script/roles/ipmi-flash/01-stub.sh
+++ b/core/script/roles/ipmi-flash/01-stub.sh
@@ -38,7 +38,7 @@ while read -r entry; do
             'ipmi-firmware-rev')
                 printf "Testing firmware version '%s' against '%s'\n" "$v" "$val"
                 version=$val
-                if ! rev_lt "$val" "${VALUES[$v]}"; then
+                if ! rev_lt "${VALUES[$v]}" "$val"; then
                     match=false
                 fi;;
             *)


### PR DESCRIPTION
VALUES[$v] is the current firmware version, and $val is the version listed for the package.