### PR TITLE
Shrink containers and remove reliance on our webproxy.

### DIFF
--- a/containers/base/Dockerfile.in
+++ b/containers/base/Dockerfile.in
@@ -1,18 +1,16 @@
-FROM ubuntu:14.04
+FROM gcr.io/google_containers/ubuntu-slim:0.5
 MAINTAINER Victor Lowther <victor@rackn.com>
-
-ENV GOPATH /go
 
 ARG DR_TAG
 
 # Get packages
-RUN mkdir -p /usr/local/sbin/ /usr/local/entrypoint.d /etc/rebar-data && \
-    apt-get update && \
-    apt-get -y dist-upgrade && \
-    apt-get install -y curl unzip git jq build-essential && \
-    curl -fgL -o '/tmp/goball.tgz' \
-         'https://storage.googleapis.com/golang/go1.7.linux-amd64.tar.gz' && \
-    tar -C '/usr/local' -zxf /tmp/goball.tgz && rm /tmp/goball.tgz
+RUN mkdir -p /usr/local/sbin/ /usr/local/entrypoint.d /etc/rebar-data \
+    && apt-get update \
+    && apt-get -y dist-upgrade \
+    && apt-get install -y bash curl ca-certificates unzip git jq build-essential wget iproute2 --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 ADD http://localhost:28569/${DR_TAG}/linux/amd64/rebar /usr/local/bin/rebar
 COPY docker-entrypoint.sh /sbin/docker-entrypoint.sh
 RUN chmod 755 /usr/local/bin/rebar

--- a/containers/base/docker-entrypoint.sh
+++ b/containers/base/docker-entrypoint.sh
@@ -36,26 +36,41 @@ rebar() {
 # be able to talk to the outside world.  It relies the proxy being registered and alive,
 # and it will wait until it is before proceeding.
 with_local_proxy() {
-    if [[ ! $(get_service consul) ]]; then
-        echo "with_local_proxy called before consul is up!"
-        echo "$0 must execute after 10 in the entrypoint script ordering"
-        echo "This is a deadlock situation"
-        sleep 600
-        exit 1
+    if [[ $USE_OUR_PROXY = YES ]]; then
+        if [[ ! $(get_service consul) ]]; then
+            echo "with_local_proxy called before consul is up!"
+            echo "$0 must execute after 10 in the entrypoint script ordering"
+            echo "This is a deadlock situation"
+            sleep 600
+            exit 1
+        fi
+        local blob=""
+        while true; do
+            local blob=$(get_service proxy-service)
+            [[ $blob && $blob != '[]' ]] && break
+            sleep 5
+        done
+        local addr=$(jq -r '.[0] |.ServiceAddress' <<< "$blob")
+        [[ $addr ]] || addr=$(jq '.[0] |.Address' <<< "$blob")
+        local port=$(jq -r '.[0] |.ServicePort' <<< "$blob")
+        export HTTP_PROXY="http://$addr:$port"
+        export HTTPS_PROXY="$HTTP_PROXY"
+        export http_proxy="$HTTP_PROXY"
+        export https_proxy="$HTTP_PROXY"
+        return 0
     fi
-    local blob=""
-    while true; do
-        local blob=$(get_service proxy-service)
-        [[ $blob && $blob != '[]' ]] && break
-        sleep 5
-    done
-    local addr=$(jq -r '.[0] |.ServiceAddress' <<< "$blob")
-    [[ $addr ]] || addr=$(jq '.[0] |.Address' <<< "$blob")
-    local port=$(jq -r '.[0] |.ServicePort' <<< "$blob")
-    export HTTP_PROXY="http://$addr:$port"
-    export HTTPS_PROXY="$HTTP_PROXY"
-    export http_proxy="$HTTP_PROXY"
-    export https_proxy="$HTTP_PROXY"
+    if [[ $UPSTREAM_HTTP_PROXY ]]; then
+        export HTTP_PROXY="$UPSTREAM_HTTP_PROXY"
+        export http_proxy="$HTTP_PROXY"
+    fi
+    if [[ $UPSTREAM_HTTPS_PROXY ]]; then
+        export HTTPS_PROXY="$UPSTREAM_HTTPS_PROXY"
+        export https_proxy="$HTTPS_PROXY"
+    fi
+    if [[ $UPSTREAM_NO_PROXY ]]; then
+        export NO_PROXY="$UPSTREAM_NO_PROXY"
+        export no_proxy="$UPSTREAM_NO_PROXY"
+    fi
 }
 
 make_service() {

--- a/containers/base/docker-entrypoint.sh
+++ b/containers/base/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
 set -e
-set -x
 set -o pipefail
+[[ $DEBUG ]] && set -x
 
 if [[ -d /usr/local/dev/bin ]]; then
     export PATH="/usr/local/dev/bin:$PATH"

--- a/containers/cloudwrap/Dockerfile.in
+++ b/containers/cloudwrap/Dockerfile.in
@@ -4,27 +4,32 @@ ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
 
 ARG DR_TAG
 
-RUN apt-get -y update && \
-    apt-get -y install software-properties-common wget && \
-    apt-add-repository ppa:brightbox/ruby-ng && \
-    add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" && \
-    apt-get -y update && \
-    apt-get -y install ruby2.2 ruby2.2-dev make cmake curl build-essential jq libxml2-dev libcurl4-openssl-dev libssl-dev python2.7-dev python-pip && \
-    gem install bundler && \
-    mkdir -p /var/cache/cloudwrap/gems
-RUN pip install pytz && \
-	pip install positional && \
-	pip install wrapt && \
-	pip install prettytable && \
-	pip install oslo.serialization && \
-	pip install requestsexceptions && \
-	pip install appdirs && \
-	pip install pyyaml && \
-	pip install simplejson && \
-	pip install unicodecsv && \
-	pip install netifaces && \
-	pip install warlock && \
-        pip install python-openstackclient
+RUN apt-get -y update \
+    && apt-get -y --no-install-recommends install software-properties-common wget \
+    && apt-add-repository -y ppa:brightbox/ruby-ng \
+    && add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" \
+    && apt-get -y update \
+    && apt-get -y --no-install-recommends install ruby2.2 ruby2.2-dev make cmake curl build-essential jq libxml2-dev libcurl4-openssl-dev libssl-dev python2.7-dev python-pip ssh tzdata iputils-ping \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \    
+    && gem install bundler \
+    && mkdir -p /var/cache/cloudwrap/gems
+
+RUN pip install --upgrade pip \
+	&& pip install setuptools \
+	&& pip install pytz \
+	&& pip install positional \
+	&& pip install wrapt \
+	&& pip install prettytable \
+	&& pip install oslo.serialization \
+	&& pip install requestsexceptions \
+	&& pip install appdirs \
+	&& pip install pyyaml \
+	&& pip install simplejson \
+	&& pip install unicodecsv \
+	&& pip install netifaces \
+	&& pip install warlock \
+    && pip install python-openstackclient
 
 COPY cloudwrap /opt/cloudwrap
 

--- a/containers/dns/Dockerfile.in
+++ b/containers/dns/Dockerfile.in
@@ -5,10 +5,12 @@ ARG DR_TAG
 
 # Get packages
 RUN apt-get update \
-  && apt-get -y install bind9 bind9utils dnsutils \
+  && apt-get -y --no-install-recommends install bind9 bind9utils dnsutils \
   && mkdir -p /etc/dns-mgmt.d \
   && mkdir -p /var/cache/rebar-dns-mgmt \
-  && chmod 700 /var/cache/rebar-dns-mgmt
+  && chmod 700 /var/cache/rebar-dns-mgmt \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Set our command
 ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
@@ -17,5 +19,3 @@ RUN chmod 755 /usr/local/bin/rebar-dns-mgmt
 COPY dns-mgmt.d/* /etc/dns-mgmt.d/
 COPY bind /etc/bind
 COPY entrypoint.d/*.sh /usr/local/entrypoint.d/
-
-

--- a/containers/forwarder/Dockerfile.in
+++ b/containers/forwarder/Dockerfile.in
@@ -2,7 +2,10 @@ FROM digitalrebar/deploy-service-wrapper
 MAINTAINER Victor Lowther <victor@rackn.com>
 
 ARG DR_TAG
-RUN apt-get install -y iptables ntp ntpdate
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends iptables ntp ntpdate \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 ADD http://localhost:28569/${DR_TAG}/linux/amd64/forwarder /usr/local/bin/forwarder
 COPY entrypoint.d/*.sh /usr/local/entrypoint.d/

--- a/containers/goiardi/Dockerfile.in
+++ b/containers/goiardi/Dockerfile.in
@@ -6,16 +6,25 @@ ARG DR_TAG
 ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
 
 # Get packages
-RUN apt-get update && \
-    apt-get -y install make build-essential cpanminus perl perl-doc libdbd-pg-perl \
-                       curl coreutils postgresql-client && \
-     /usr/local/go/bin/go get -v github.com/ctdk/goiardi && \
-     cpanm --quiet --notest App::Sqitch && \
-     mkdir -p /etc/goiardi /var/cache/goiardi && \
-     apt-get -y purge make build-essential && \
-     curl -fgL -o '/tmp/chef.deb' \
-       'https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86_64/chef_11.18.12-1_amd64.deb' && \
-     dpkg -i /tmp/chef.deb && rm -f /tmp/chef.deb
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install make build-essential cpanminus perl perl-doc libdbd-pg-perl \
+      curl coreutils postgresql-client \
+    && cpanm --quiet --notest App::Sqitch \
+    && mkdir -p /etc/goiardi /var/cache/goiardi \
+    && apt-get -y purge make build-essential \
+    && curl -fgL -o '/tmp/chef.deb' \
+      'https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86_64/chef_11.18.12-1_amd64.deb' \
+    && dpkg -i /tmp/chef.deb && rm -f /tmp/chef.deb \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*    
+
+ADD https://github.com/ctdk/goiardi/releases/download/v0.11.0/goiardi-0.11.0-linux-amd64 /usr/local/bin/goiardi
+ADD https://github.com/ctdk/goiardi/archive/v0.11.0.tar.gz /tmp/goiardi.tar.gz
+RUN chmod 755 /usr/local/bin/goiardi \
+    && cd /tmp \
+    && tar xf goiardi.tar.gz \
+    && mv goiardi*/sql-files/postgres-bundle . \
+    && rm -rf goiardi*
 
 COPY goiardi.conf /tmp
 COPY entrypoint.d/*.sh /usr/local/entrypoint.d/

--- a/containers/goiardi/entrypoint.d/20-create-postgres-database.sh
+++ b/containers/goiardi/entrypoint.d/20-create-postgres-database.sh
@@ -2,7 +2,7 @@
 
 tmpdir=$(mktemp -d /tmp/sqitch-XXXXXX)
 cd "$tmpdir"
-cp -a "/go/src/github.com/ctdk/goiardi/sql-files/postgres-bundle/"* .
+cp -a /tmp/postgres-bundle/* .
 export PGPASSWORD=$POSTGRES_PASSWORD
 addr="$(curl http://localhost:8500/v1/catalog/service/rebar-database |jq -r '.[0].Address')"
 while ! psql -U $POSTGRES_USER -h "$addr" goiardi -c 'select 1;'; do
@@ -12,7 +12,6 @@ done
 
 sqitch target add goiardi db:pg://$POSTGRES_USER:$POSTGRES_PASSWORD@"$addr"/goiardi
 sqitch verify goiardi || sqitch deploy goiardi
-
 
 psql -U $POSTGRES_USER -h "$addr" goiardi -c "grant all on database goiardi to goiardi;"
 psql -U $POSTGRES_USER -h "$addr" goiardi -c "grant all on schema goiardi to goiardi;"

--- a/containers/goiardi/entrypoint.d/25-start-goiardi.sh
+++ b/containers/goiardi/entrypoint.d/25-start-goiardi.sh
@@ -18,7 +18,7 @@ if [[ $first_start ]]; then
 fi
 chmod 400 /etc/goiardi/server.key /etc/goiardi/server.crt /etc/goiardi/*.key
 
-/go/bin/goiardi -c /etc/goiardi/goiardi.conf &
+/usr/local/bin/goiardi -c /etc/goiardi/goiardi.conf &
 
 if [[ $first_start ]]; then
     count=0

--- a/containers/logging/Dockerfile.in
+++ b/containers/logging/Dockerfile.in
@@ -4,7 +4,10 @@ MAINTAINER Victor Lowther <victor@rackn.com>
 ARG DR_TAG
 ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
 
-RUN apt-get update && apt-get -y install rsyslog rsyslog-relp logrotate
+RUN apt-get update \
+  && apt-get -y --no-install-recommends install rsyslog rsyslog-relp logrotate \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY rsyslog.conf /etc/rsyslog.conf
 COPY logrotate.conf /etc/logrotate.conf

--- a/containers/node/Dockerfile.in
+++ b/containers/node/Dockerfile.in
@@ -1,17 +1,14 @@
-FROM ubuntu:14.04
-
-# TORUN
-
-ENV GOPATH /go
+FROM gcr.io/google_containers/ubuntu-slim:0.5
 
 ARG DR_TAG
+
 # Set our command
 ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
 
 # Get packages
 RUN apt-get update \
-  && apt-get -y install git jq openssh-server curl \
-  && curl -fgL -o '/tmp/chef.deb' 'http://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/12.04/x86_64/chef_11.12.8-1_amd64.deb' \
+  && apt-get -y --no-install-recommends install git jq openssh-server curl ca-certificates \
+  && curl -fgL -o '/tmp/chef.deb' 'https://packages.chef.io/stable/ubuntu/12.04/chef_12.16.42-1_amd64.deb' \
   && dpkg -i /tmp/chef.deb \
   && rm -f /tmp/chef.deb
 ADD http://localhost:28569/${DR_TAG}/linux/amd64/rebar /usr/local/bin/rebar

--- a/containers/ntp/Dockerfile.in
+++ b/containers/ntp/Dockerfile.in
@@ -2,7 +2,10 @@ FROM digitalrebar/deploy-service-wrapper
 MAINTAINER Victor Lowther <victor@rackn.com>
 
 ARG DR_TAG
-RUN apt-get install -y ntp
+RUN apt-get update \
+    && apt-get install -y ntp \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.d/*.sh /usr/local/entrypoint.d/ 
 

--- a/containers/postgres/Dockerfile.in
+++ b/containers/postgres/Dockerfile.in
@@ -5,21 +5,6 @@ ARG DR_TAG
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r postgres && useradd -r -g postgres postgres
 
-# grab gosu for easy step-down from root
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
-	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& apt-get purge -y --auto-remove ca-certificates wget
-
-# make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
-RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
-	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-ENV LANG en_US.utf8
-
 RUN mkdir /docker-entrypoint-initdb.d
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
@@ -28,20 +13,32 @@ ENV PG_MAJOR 9.5
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 
-RUN apt-get update \
-	&& apt-get install -y postgresql-common curl zip jq \
+# grab gosu for easy step-down from root
+RUN gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+RUN apt-get update && apt-get install -y ca-certificates wget curl unzip zip jq locales postgresql-common \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
+	&& gpg --verify /usr/local/bin/gosu.asc \
+	&& rm /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
 	&& sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf \
-	&& apt-get install -y \
+	&& apt-get install -y --no-install-recommends \
 		postgresql-$PG_MAJOR \
 		postgresql-contrib-$PG_MAJOR \
-	&& rm -rf /var/lib/apt/lists/*
+	&& apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
+ENV LANG en_US.utf8
 
 RUN mkdir -p /var/run/postgresql && chown -R postgres /var/run/postgresql
 
 # Consul for now
-RUN mkdir -p /tmp/consul && \
- curl -fL -o consul.zip https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip && \
- unzip consul.zip -d /usr/local/bin && rm consul.zip
+RUN mkdir -p /tmp/consul \
+ && wget -O consul.zip https://releases.hashicorp.com/consul/0.7.1/consul_0.7.1_linux_amd64.zip \
+ && unzip consul.zip -d /usr/local/bin \
+ && rm consul.zip
 
 RUN mkdir -p /etc/consul.d
 COPY database.json /etc/consul.d/database.json

--- a/containers/provisioner/Dockerfile.in
+++ b/containers/provisioner/Dockerfile.in
@@ -29,8 +29,8 @@ RUN chmod 755 /usr/local/bin/*
 # Set our command
 ENTRYPOINT ["/sbin/docker-entrypoint.sh"]       
 
-# Get Latest Go
-RUN apt-get -y update && apt-get -y install bsdtar createrepo xz-utils unzip bsdmainutils p7zip-full samba
-RUN apt-get -y purge make build-essential
+RUN apt-get -y update \
+    && apt-get -y install bsdtar createrepo xz-utils unzip bsdmainutils p7zip-full samba \
+    && apt-get -y purge make build-essential
 
 COPY smb.conf /etc/samba/smb.conf

--- a/containers/rebar-api/Dockerfile.in
+++ b/containers/rebar-api/Dockerfile.in
@@ -13,14 +13,18 @@ COPY ssh_config /home/rebar/.ssh/config
 COPY rebar-runner.json /etc/consul.d/rebar-runner.json
 
 RUN apt-get -y update \
-  && apt-get -y install software-properties-common wget \
+  && apt-get -y install software-properties-common\
   && apt-add-repository ppa:brightbox/ruby-ng \
   && add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-backports main restricted universe multiverse" \
-  && add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" \
+  && add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" \
   && apt-add-repository ppa:ansible/ansible \
-  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - \
+  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
   && apt-get -y update \
-  && apt-get -y install ruby2.1 ruby2.1-dev make cmake curl libxml2-dev libcurl4-openssl-dev libssl-dev build-essential jq sudo postgresql-client-9.5 libpq5 libpq-dev autoconf uuid-runtime ipmitool ansible python-netaddr python-dns python-pip
+  && apt-get -y --no-install-recommends install ruby2.1 ruby2.1-dev make cmake curl libxml2-dev libcurl4-openssl-dev libssl-dev build-essential jq sudo postgresql-client-9.5 libpq5 libpq-dev autoconf uuid-runtime ipmitool ansible python-netaddr python-dns python-pip ssh tzdata iputils-ping \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip
 RUN pip install dnspython
 RUN gem install bundler \
   && gem install net-http-digest_auth \
@@ -41,11 +45,11 @@ RUN ln -s /var/cache/rebar/bin/puma /usr/bin/puma \
   && chmod 400 /var/run/rebar/server.key /var/run/rebar/server.crt \
   && chown rebar:rebar /var/run/rebar/server.key /var/run/rebar/server.crt
 RUN curl -fgL -o '/tmp/chef.deb' \
-       'https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86_64/chef_11.18.12-1_amd64.deb' \
+  'https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86_64/chef_11.18.12-1_amd64.deb' \
   && dpkg -i /tmp/chef.deb && rm -f /tmp/chef.deb \
   && sed -i '/\[ssh_connection\]/a ssh_args=' /etc/ansible/ansible.cfg
-RUN /usr/local/go/bin/go get -u github.com/VictorLowther/intelamt/amttool \
-  && mv /go/bin/amttool /usr/local/bin/amttool \
-  && /usr/local/go/bin/go get -u github.com/VictorLowther/wsman/wscli
+
+ADD http://localhost:28569/${DR_TAG}/linux/amd64/amttool /usr/local/bin/amttool
+ADD http://localhost:28569/${DR_TAG}/linux/amd64/wscli /usr/local/bin/wscli
 
 COPY entrypoint.d/*.sh /usr/local/entrypoint.d/

--- a/containers/rebar-rev-proxy/Dockerfile.in
+++ b/containers/rebar-rev-proxy/Dockerfile.in
@@ -10,11 +10,13 @@ ENTRYPOINT ["/sbin/docker-entrypoint.sh"]
 
 ADD http://localhost:28569/${DR_TAG}/linux/amd64/rebar-rev-proxy /usr/local/bin/
 RUN apt-get -y update \
-    && apt-get install -y xmlsec1 nodejs nodejs-legacy npm \
+    && apt-get install -y --no-install-recommends xmlsec1 nodejs nodejs-legacy npm \
     && npm install -g bower n \
     && n stable \
     && chmod 755 /usr/local/bin/* \
-    && mkdir -p /opt/digitalrebar-ux
+    && mkdir -p /opt/digitalrebar-ux \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*    
 RUN git clone -b ${DR_TAG} https://github.com/rackn/digitalrebar-ux /opt/digitalrebar-ux \
   && cd /opt/digitalrebar-ux \
   && bower --allow-root install --config.interactive=false \

--- a/containers/rebuild-containers
+++ b/containers/rebuild-containers
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+[[ $DEBUG ]] && set -x
+
 #
 # NOTE: When building on MAC, you must set SWS_LISTEN_ADDR to your docker
 # bridge IP (e.g. 192.168.99.1) and accept the mac firewall port allowance.
@@ -265,13 +267,30 @@ if [[ ${#CONTAINERS_TO_BUILD[@]} == 0 ]]; then
     exit 0
 fi
 
+if [ -z ${GOPATH+x} ]; then
+    echo "Please configure \$GOPATH variable"
+    exit 1
+fi
+
 if ! which sws; then
     go get -u github.com/VictorLowther/sws
+fi
+
+if ! which sws; then
+    echo "Please verify \$GOPTAH/bin is in \$PATH"
+    exit 1
 fi
 
 SWS_LISTEN_ADDR=${SWS_LISTEN_ADDR:-localhost}
 sws -listen ${SWS_LISTEN_ADDR}:28569 -site ../go/bin &
 trap 'kill %1' INT TERM EXIT KILL
+
+# install required go binaries
+binpath="$CONTAINER_DIR/../go/bin/$DR_TAG/linux/amd64"
+mkdir -p "$binpath"
+GOBIN="$binpath" GOOS="linux" GOARCH="amd64" go get github.com/ctdk/goiardi
+GOBIN="$binpath" GOOS="linux" GOARCH="amd64" go get github.com/VictorLowther/intelamt/amttool
+GOBIN="$binpath" GOOS="linux" GOARCH="amd64" go get github.com/VictorLowther/wsman/wscli
 
 for container in $(sort_containers "${!CONTAINERS_TO_BUILD[@]}"); do
     [[ ${BUILT_CONTAINERS[$container]} ]] || build_container "$container" || break

--- a/containers/service-wrapper/Dockerfile.in
+++ b/containers/service-wrapper/Dockerfile.in
@@ -5,11 +5,11 @@ RUN echo ${DR_TAG}
 ARG DR_TAG
 RUN echo ${DR_TAG}
 
-RUN mkdir -p /tmp/consul /etc/consul.d  && \
-    curl -fgL -o consul.zip \
-        https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip && \
-    unzip consul.zip -d /usr/local/bin && \
-    rm consul.zip
+RUN mkdir -p /tmp/consul /etc/consul.d \
+    && curl -fgL -o consul.zip \
+      https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_linux_amd64.zip \
+    && unzip consul.zip -d /usr/local/bin \
+    && rm consul.zip
 ADD http://localhost:28569/${DR_TAG}/linux/amd64/sign-it /usr/local/bin/
 RUN chmod 755 /usr/local/bin/*
 

--- a/containers/slave/Dockerfile.in
+++ b/containers/slave/Dockerfile.in
@@ -8,15 +8,15 @@ ARG DR_TAG=
 RUN apk update && apk upgrade
 RUN apk add bash bash-completion curl jq git go openssh
 
-RUN mkdir -p linux/amd64 && \
-    curl -fgL https://s3-us-west-2.amazonaws.com/rebar-bins/${DR_TAG}/linux/amd64/rebar \
-         -o linux/amd64/rebar && \
-    curl -fgL https://s3-us-west-2.amazonaws.com/rebar-bins/${DR_TAG}/sha256sums \
-         -o rebar-bins.sha256sum && \
-    (grep "linux/amd64/rebar\$" rebar-bins.sha256sum | sha256sum -c && rm rebar-bins.sha256sum) && \
-    mv linux/amd64/rebar /usr/local/bin/rebar && \
-    chmod 755 /usr/local/bin/rebar && \
-    rm -rf linux
+RUN mkdir -p linux/amd64 \
+    && curl -fgL https://s3-us-west-2.amazonaws.com/rebar-bins/${DR_TAG}/linux/amd64/rebar \
+      -o linux/amd64/rebar \
+    && curl -fgL https://s3-us-west-2.amazonaws.com/rebar-bins/${DR_TAG}/sha256sums \
+      -o rebar-bins.sha256sum \
+    && (grep "linux/amd64/rebar\$" rebar-bins.sha256sum | sha256sum -c && rm rebar-bins.sha256sum) \
+    && mv linux/amd64/rebar /usr/local/bin/rebar \
+    && chmod 755 /usr/local/bin/rebar \
+    && rm -rf linux
 
 # Add Chef
 

--- a/containers/webproxy/Dockerfile.in
+++ b/containers/webproxy/Dockerfile.in
@@ -3,17 +3,38 @@ MAINTAINER Victor Lowther <victor@rackn.com>
 
 ARG DR_TAG
 
-ENV SQUID_VERSION=3.3.8 \
-    SQUID_CACHE_DIR=/var/spool/squid3 \
+ENV SQUID_CACHE_DIR=/var/spool/squid3 \
     SQUID_LOG_DIR=/var/log/squid3 \
     SQUID_USER=proxy
+COPY rules.patch /tmp
+ADD http://archive.ubuntu.com/ubuntu/pool/main/s/squid3/squid3_3.5.12-1ubuntu8.dsc /tmp/squid-build/squid3_3.5.12-1ubuntu8.dsc
+ADD http://archive.ubuntu.com/ubuntu/pool/main/s/squid3/squid3_3.5.12.orig.tar.gz /tmp/squid-build/squid3_3.5.12.orig.tar.gz
+ADD http://archive.ubuntu.com/ubuntu/pool/main/s/squid3/squid3_3.5.12-1ubuntu8.debian.tar.xz /tmp/squid-build/squid3_3.5.12-1ubuntu8.debian.tar.xz
 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 80F70E11F0F0D5F10CB20E62F5DA5F09C3173AA6 \
- && echo "deb http://ppa.launchpad.net/brightbox/squid-ssl/ubuntu trusty main" >> /etc/apt/sources.list \
- && apt-get update \
- && apt-get install -y squid3-ssl=${SQUID_VERSION}* \
- && mv /etc/squid3/squid.conf /etc/squid3/squid.conf.dist \
- && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get -y install libecap3 devscripts build-essential \
+       fakeroot debhelper dh-autoreconf cdbs squid3 squid-langpack \
+       nettle-dev libgnutls28-dev libssl-dev libdbi-perl \
+       libldap2-dev libpam0g-dev libdb-dev libsasl2-dev libcppunit-dev \
+       libkrb5-dev  comerr-dev  libcap2-dev libecap3-dev libexpat1-dev \
+       libxml2-dev libnetfilter-conntrack-dev dh-apparmor bash \
+    && cd /tmp/squid-build \
+    && dpkg-source -x squid3_3.5.12-1ubuntu8.dsc \
+    && patch squid3-3.5.12/debian/rules < /tmp/rules.patch \
+    && cd squid3-3.5.12 && dpkg-buildpackage -rfakeroot -b -jauto \
+    && cd /tmp/squid-build \
+    && dpkg --install squid-common_3.5.12-1ubuntu8_all.deb \
+    && dpkg --install squid_3.5.12-1ubuntu8_amd64.deb \
+    && dpkg --install squidclient_3.5.12-1ubuntu8_amd64.deb \
+    && cd .. \
+    && rm -rf /tmp/squid-build \
+    && apt-get purge -y --auto-remove  devscripts build-essential fakeroot debhelper \
+               dh-autoreconf cdbs nettle-dev libgnutls28-dev libssl-dev libldap2-dev \
+               libpam0g-dev libsasl2-dev libcppunit-dev libkrb5-dev comerr-dev \
+               libcap2-dev libecap3-dev libexpat1-dev libxml2-dev \
+               libnetfilter-conntrack-dev dh-apparmor \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY squid.conf /tmp/squid.conf
 COPY entrypoint.d/*.sh /usr/local/entrypoint.d/

--- a/containers/webproxy/Makefile
+++ b/containers/webproxy/Makefile
@@ -1,0 +1,7 @@
+BUILD_IMAGE=squid-build
+all:
+    docker rm -f $(BUILD_IMAGE)
+    docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE):latest true
+    docker cp $(BUILD_IMAGE):/debs/squid-common_3.5.12-1ubuntu8_all.deb .
+    docker cp $(BUILD_IMAGE):/debs/squid_3.5.12-1ubuntu8_amd64.deb .
+    docker cp $(BUILD_IMAGE):/debs/squidclient_3.5.12-1ubuntu8_amd64.deb .

--- a/containers/webproxy/rules.patch
+++ b/containers/webproxy/rules.patch
@@ -1,0 +1,14 @@
+--- build/squid3/squid3-3.5.12/debian/rules	2016-02-17 01:13:33.000000000 +0100
++++ build/squid3/squid3-3.5.12/debian/rules.new	2016-02-22 22:50:04.079470555 +0100
+@@ -46,7 +46,10 @@
+ 		--with-pidfile=/var/run/squid.pid \
+ 		--with-filedescriptors=65536 \
+ 		--with-large-files \
+-		--with-default-user=proxy
++		--with-default-user=proxy \
++		--with-openssl \
++		--enable-ssl \
++		--enable-ssl-crtd
+ 
+ BUILDINFO := $(shell lsb_release -si 2>/dev/null)
+ 

--- a/containers/webproxy/squid/Dockerfile
+++ b/containers/webproxy/squid/Dockerfile
@@ -1,0 +1,12 @@
+FROM gcr.io/google_containers/ubuntu-slim:0.5
+
+ENV SQUID_CACHE_DIR=/var/spool/squid3 \
+    SQUID_LOG_DIR=/var/log/squid3 \
+    SQUID_USER=proxy
+
+COPY install.sh /tmp
+COPY rules.path /tmp
+
+RUN mkdir -p /debs && /tmp/install.sh
+
+COPY /tmp/*.deb /debs

--- a/containers/webproxy/squid/Makefile
+++ b/containers/webproxy/squid/Makefile
@@ -1,0 +1,9 @@
+
+BUILD_IMAGE=squid-build
+
+all:
+    docker rm -f $(BUILD_IMAGE)
+    docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE):latest true
+    docker cp $(BUILD_IMAGE):/debs/squid-common_3.5.12-1ubuntu8_all.deb .
+    docker cp $(BUILD_IMAGE):/debs/squid_3.5.12-1ubuntu8_amd64.deb .
+    docker cp $(BUILD_IMAGE):/debs/squidclient_3.5.12-1ubuntu8_amd64.deb .

--- a/containers/webproxy/squid/install.sh
+++ b/containers/webproxy/squid/install.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+apt-get update \
+    && apt-get -y install libecap3 devscripts build-essential \
+    fakeroot debhelper dh-autoreconf cdbs squid3 squid-langpack \
+    nettle-dev libgnutls28-dev libssl-dev libdbi-perl wget \
+    libldap2-dev libpam0g-dev libdb-dev libsasl2-dev libcppunit-dev \
+    libkrb5-dev comerr-dev libcap2-dev libecap3-dev libexpat1-dev \
+    libxml2-dev libnetfilter-conntrack-dev dh-apparmor bash
+
+wget http://archive.ubuntu.com/ubuntu/pool/main/s/squid3/squid3_3.5.12-1ubuntu8.dsc
+wget http://archive.ubuntu.com/ubuntu/pool/main/s/squid3/squid3_3.5.12.orig.tar.gz
+wget http://archive.ubuntu.com/ubuntu/pool/main/s/squid3/squid3_3.5.12-1ubuntu8.debian.tar.xz
+
+dpkg-source -x squid3_3.5.12-1ubuntu8.dsc
+
+patch squid3-3.5.12/debian/rules < /tmp/rules.patch
+
+cd squid3-3.5.12 && dpkg-buildpackage -rfakeroot -b
+
+cp *.deb /debs

--- a/containers/webproxy/squid/rules.patch
+++ b/containers/webproxy/squid/rules.patch
@@ -1,0 +1,14 @@
+--- build/squid3/squid3-3.5.12/debian/rules	2016-02-17 01:13:33.000000000 +0100
++++ build/squid3/squid3-3.5.12/debian/rules.new	2016-02-22 22:50:04.079470555 +0100
+@@ -46,7 +46,10 @@
+ 		--with-pidfile=/var/run/squid.pid \
+ 		--with-filedescriptors=65536 \
+ 		--with-large-files \
+-		--with-default-user=proxy
++		--with-default-user=proxy \
++		--with-openssl \
++		--enable-ssl \
++		--enable-ssl-crtd
+ 
+ BUILDINFO := $(shell lsb_release -si 2>/dev/null)
+ 

--- a/core/barclamps/proxy.yml
+++ b/core/barclamps/proxy.yml
@@ -93,7 +93,7 @@ attribs:
   - name: use-proxy
     description: 'Whether the node should attempt to use the proxy service'
     map: 'rebar/providers/use_proxy'
-    default: true
+    default: false
     schema:
       type: bool
       required: true

--- a/core/bin/barclamp_import
+++ b/core/bin/barclamp_import
@@ -132,7 +132,10 @@ $rule_engine = nil
 
 loop do
   rev_proxies, code = REST.get("http://localhost:8500/v1/catalog/service/rebar-rev-proxy-service")
-  next if code != 200 || rev_proxies[0].nil?
+  if code != 200 || rev_proxies[0].nil?
+    sleep 1
+    next
+  end
   addr = rev_proxies[0]["ServiceAddress"]
   addr = rev_proxies[0]["Address"] unless addr and !addr.empty?
   $rule_engine = "https://#{addr}/rule-engine/api/v0/rulesets/"

--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   puts "==========================================================="
 
   config.vm.define "client", autostart:false do |client|
-  
+
     client.vm.box = ADMIN_OS_BOX
     client.vm.provider "virtualbox" do |vb|
       vb.memory = SLAVE_RAM

--- a/deploy/compose/config-dir/provisioner/bootenvs/centos-6.6.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/centos-6.6.json
@@ -15,6 +15,7 @@
         "ntp_servers",
         "operating-system-disk",
         "provisioner-default-password-hash",
+        "use-proxy",
         "proxy-servers",
         "rebar-access_keys",
         "rebar-machine_key"

--- a/deploy/compose/config-dir/provisioner/bootenvs/centos-7.1.1503.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/centos-7.1.1503.json
@@ -16,6 +16,7 @@
         "operating-system-disk",
         "provisioner-default-password-hash",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/centos-7.2.1511.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/centos-7.2.1511.json
@@ -16,6 +16,7 @@
         "operating-system-disk",
         "provisioner-default-password-hash",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/debian-7.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/debian-7.json
@@ -21,6 +21,7 @@
         "provisioner-default-user",
         "provisioner-use-local-security",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/debian-8.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/debian-8.json
@@ -21,6 +21,7 @@
         "provisioner-default-user",
         "provisioner-use-local-security",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/redhat-6.5.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/redhat-6.5.json
@@ -15,6 +15,7 @@
         "operating-system-disk",
         "provisioner-default-password-hash",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-12.04.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-12.04.json
@@ -21,6 +21,7 @@
         "provisioner-default-user",
         "provisioner-use-local-security",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-14.04.3.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-14.04.3.json
@@ -21,6 +21,7 @@
         "provisioner-default-user",
         "provisioner-use-local-security",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-14.04.4.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-14.04.4.json
@@ -21,6 +21,7 @@
         "provisioner-default-user",
         "provisioner-use-local-security",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-15.04.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-15.04.json
@@ -21,6 +21,7 @@
         "provisioner-default-user",
         "provisioner-use-local-security",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-16.04.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-16.04.json
@@ -21,6 +21,7 @@
         "provisioner-default-user",
         "provisioner-use-local-security",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key"
     ],

--- a/deploy/compose/config-dir/provisioner/bootenvs/windows-2012r2.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/windows-2012r2.json
@@ -15,6 +15,7 @@
         "operating-system-disk",
         "provisioner-default-password-hash",
         "proxy-servers",
+        "use-proxy",
         "rebar-access_keys",
         "rebar-machine_key",
         "operating-system-license-key",

--- a/deploy/compose/config-dir/provisioner/templates/centos-6.ks.tmpl
+++ b/deploy/compose/config-dir/provisioner/templates/centos-6.ks.tmpl
@@ -2,7 +2,7 @@
 install
 url --url {{ .Env.OS.InstallUrl }}
 # Add support for our local proxy.
-repo --name="CentOS"  --baseurl={{ .Env.OS.InstallUrl }} {{if .Param "proxy-servers"}} --proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}} --cost=100
+repo --name="CentOS"  --baseurl={{ .Env.OS.InstallUrl }} {{if .Param "use-proxy"}} --proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}} --cost=100
 key --skip
 lang en_US.UTF-8
 keyboard us
@@ -68,7 +68,7 @@ name=Rebar Epel Repo
 baseurl=http://mirrors.kernel.org/fedora-epel/6/x86_64/
 gpgcheck=0
 EOF
-{{if .Param "proxy-servers"}}
+{{if .Param "use-proxy"}}
 echo "proxy={{index (.Param "proxy-servers") 0 "url"}}" >> /etc/yum.conf
 {{end}}
 sed -i '/^enabled/ s/1/0/' /etc/yum/pluginconf.d/fastestmirror.conf
@@ -77,7 +77,7 @@ sed -i '/^enabled/ s/1/0/' /etc/yum/pluginconf.d/fastestmirror.conf
 cat >/etc/gemrc <<EOF
 :sources:
 - http://rubygems.org/
-gem: --no-ri --no-rdoc --bindir /usr/local/bin {{if .Param "proxy-servers"}} --http-proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}}
+gem: --no-ri --no-rdoc --bindir /usr/local/bin {{if .Param "use-proxy"}} --http-proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}}
 EOF
 
 cp /etc/gemrc /root/.gemrc
@@ -123,7 +123,7 @@ echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config
 # Allow client to pass http proxy environment variables
 echo "AcceptEnv http_proxy https_proxy no_proxy" >> /etc/ssh/sshd_config
 
-{{if .Param "proxy-servers"}}
+{{if .Param "use-proxy"}}
 # Setup a proxy for the environment
 echo "http_proxy={{index (.Param "proxy-servers") 0 "url"}}" >> /etc/environment
 echo "https_proxy={{index (.Param "proxy-servers") 0 "url"}}" >> /etc/environment

--- a/deploy/compose/config-dir/provisioner/templates/centos-7.ks.tmpl
+++ b/deploy/compose/config-dir/provisioner/templates/centos-7.ks.tmpl
@@ -3,7 +3,7 @@
 install
 url --url {{ .Env.OS.InstallUrl }}
 # Add support for our local proxy.
-repo --name="CentOS"  --baseurl={{ .Env.OS.InstallUrl }} {{if .Param "proxy-servers"}} --proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}} --cost=100
+repo --name="CentOS"  --baseurl={{ .Env.OS.InstallUrl }} {{if .Param "use-proxy"}} --proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}} --cost=100
 # key --skip
 # Disable geolocation for language and timezone
 # Currently broken by https://bugzilla.redhat.com/show_bug.cgi?id=1111717
@@ -65,7 +65,7 @@ name=Rebar Epel Repo
 baseurl=http://mirrors.kernel.org/fedora-epel/7/x86_64/
 gpgcheck=0
 EOF
-{{if .Param "proxy-servers"}}
+{{if .Param "use-proxy"}}
 echo "proxy={{index (.Param "proxy-servers") 0 "url"}}" >> /etc/yum.conf
 {{end}}
 sed -i '/^enabled/ s/1/0/' /etc/yum/pluginconf.d/fastestmirror.conf
@@ -96,7 +96,7 @@ echo "$REBAR_UUID" > /etc/rebar-uuid
 cat >/etc/gemrc <<EOF
 :sources:
 - http://rubygems.org/
-gem: --no-ri --no-rdoc --bindir /usr/local/bin {{if .Param "proxy-servers"}} --http-proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}}
+gem: --no-ri --no-rdoc --bindir /usr/local/bin {{if .Param "use-proxy"}} --http-proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}}
 EOF
 cp /etc/gemrc /root/.gemrc
 
@@ -118,7 +118,7 @@ EOF
 echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config
 echo "AcceptEnv http_proxy https_proxy no_proxy" >> /etc/ssh/sshd_config
 
-{{if .Param "proxy-servers"}}
+{{if .Param "use-proxy"}}
 # Setup a proxy for the environment
 echo "http_proxy={{index (.Param "proxy-servers") 0 "url"}}" >> /etc/environment
 echo "https_proxy={{index (.Param "proxy-servers") 0 "url"}}" >> /etc/environment

--- a/deploy/compose/config-dir/provisioner/templates/net-post-install.sh.tmpl
+++ b/deploy/compose/config-dir/provisioner/templates/net-post-install.sh.tmpl
@@ -17,7 +17,7 @@
 set -x
 exec 2>&1
 exec >>/target/root/post-install.log
-{{if .Param "proxy-servers"}}
+{{if .Param "use-proxy"}}
 echo "Acquire::http::Proxy \"{{index (.Param "proxy-servers") 0 "url"}}\";" >/target/etc/apt/apt.conf.d/00-proxy
 {{end}}
 
@@ -37,7 +37,7 @@ fi
 cat >/target/etc/gemrc <<EOF
 :sources:
 - http://rubygems.org/
-gem: --no-ri --no-rdoc --bindir /usr/local/bin {{if .Param "proxy-servers"}} --http-proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}}
+gem: --no-ri --no-rdoc --bindir /usr/local/bin {{if .Param "use-proxy"}} --http-proxy="{{index (.Param "proxy-servers") 0 "url"}}"{{end}}
 EOF
 
 cp /target/etc/gemrc /target/root/.gemrc
@@ -53,7 +53,7 @@ EOF
 echo "PermitRootLogin without-password" >> /target/etc/ssh/sshd_config
 echo "AcceptEnv http_proxy https_proxy no_proxy" >> /target/etc/ssh/sshd_config
 
-{{if .Param "proxy-servers"}}
+{{if .Param "use-proxy"}}
 # Setup a proxy for the environment
 echo "http_proxy={{index (.Param "proxy-servers") 0 "url"}}" >> /target/etc/environment
 echo "https_proxy={{index (.Param "proxy-servers") 0 "url"}}" >> /target/etc/environment

--- a/deploy/compose/config-dir/provisioner/templates/net_seed.tmpl
+++ b/deploy/compose/config-dir/provisioner/templates/net_seed.tmpl
@@ -22,7 +22,7 @@ d-i mirror/protocol string {{.ParseUrl "scheme" .Env.OS.InstallUrl}}
 d-i mirror/http/hostname string {{.ParseUrl "host" .Env.OS.InstallUrl}}
 d-i mirror/http/directory string {{.ParseUrl "path" .Env.OS.InstallUrl}}
 {{end}}
-{{if .Param "proxy-servers"}}
+{{if .Param "use-proxy"}}
 d-i mirror/http/proxy string {{index (.Param "proxy-servers") 0 "url"}}
 {{else}}
 d-i mirror/http/proxy string

--- a/go/build-rebar.sh
+++ b/go/build-rebar.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+[[ $DEBUG ]] && set -x
+
 # Requires GOPATH to be set and will use it
 
 branch="$(git symbolic-ref -q HEAD)"


### PR DESCRIPTION
This pull request contains an updated version of the container shrinking that actually allows the Digitial Rebar cluster to come up, switches the default for use-proxy to false while adding changes that let the provisioner honor that attrib, and modifies our bringup process to not implicitly use the webproxy for everything.

Note that the webproxy container still comes up -- tearing out the implicit dependencies on the proxy roles will require some rework.