### PR TITLE
Dhcp unlease use proxy fixes build tweak

### DIFF
--- a/containers/rebuild-containers
+++ b/containers/rebuild-containers
@@ -288,6 +288,8 @@ trap 'kill %1' INT TERM EXIT KILL
 # install required go binaries
 binpath="$CONTAINER_DIR/../go/bin/$DR_TAG/linux/amd64"
 mkdir -p "$binpath"
+os=linux
+arch=amd64
 GOOS="$os" GOARCH="$arch" go build -o "${binpath}/goiardi" "github.com/ctdk/goiardi"
 GOOS="$os" GOARCH="$arch" go build -o "${binpath}/amttool" "github.com/VictorLowther/intelamt/amttool"
 GOOS="$os" GOARCH="$arch" go build -o "${binpath}/wscli" "github.com/VictorLowther/wsman/wscli"

--- a/containers/rebuild-containers
+++ b/containers/rebuild-containers
@@ -288,8 +288,8 @@ trap 'kill %1' INT TERM EXIT KILL
 # install required go binaries
 binpath="$CONTAINER_DIR/../go/bin/$DR_TAG/linux/amd64"
 mkdir -p "$binpath"
-os=linux
-arch=amd64
+os="linux"
+arch="amd64"
 GOOS="$os" GOARCH="$arch" go build -o "${binpath}/goiardi" "github.com/ctdk/goiardi"
 GOOS="$os" GOARCH="$arch" go build -o "${binpath}/amttool" "github.com/VictorLowther/intelamt/amttool"
 GOOS="$os" GOARCH="$arch" go build -o "${binpath}/wscli" "github.com/VictorLowther/wsman/wscli"

--- a/containers/rebuild-containers
+++ b/containers/rebuild-containers
@@ -288,9 +288,9 @@ trap 'kill %1' INT TERM EXIT KILL
 # install required go binaries
 binpath="$CONTAINER_DIR/../go/bin/$DR_TAG/linux/amd64"
 mkdir -p "$binpath"
-GOBIN="$binpath" GOOS="linux" GOARCH="amd64" go get github.com/ctdk/goiardi
-GOBIN="$binpath" GOOS="linux" GOARCH="amd64" go get github.com/VictorLowther/intelamt/amttool
-GOBIN="$binpath" GOOS="linux" GOARCH="amd64" go get github.com/VictorLowther/wsman/wscli
+GOOS="$os" GOARCH="$arch" go build -o "${binpath}/goiardi" "github.com/ctdk/goiardi"
+GOOS="$os" GOARCH="$arch" go build -o "${binpath}/amttool" "github.com/VictorLowther/intelamt/amttool"
+GOOS="$os" GOARCH="$arch" go build -o "${binpath}/wscli" "github.com/VictorLowther/wsman/wscli"
 
 for container in $(sort_containers "${!CONTAINERS_TO_BUILD[@]}"); do
     [[ ${BUILT_CONTAINERS[$container]} ]] || build_container "$container" || break

--- a/deploy/compose/config-dir/provisioner/bootenvs/redhat-7.0.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/redhat-7.0.json
@@ -14,7 +14,8 @@
         "provisioner-default-password-hash",
         "proxy-servers",
         "rebar-access_keys",
-        "rebar-machine_key"
+        "rebar-machine_key",
+        "use-proxy"
     ],
     "Templates": [
         {

--- a/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-14.04.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-14.04.json
@@ -22,7 +22,8 @@
         "provisioner-use-local-security",
         "proxy-servers",
         "rebar-access_keys",
-        "rebar-machine_key"
+        "rebar-machine_key",
+        "use-proxy"
     ],
     "Templates": [
         {

--- a/go/rebar-api/rebar/dhcp.go
+++ b/go/rebar-api/rebar/dhcp.go
@@ -174,6 +174,32 @@ func init() {
 		},
 	})
 	subnet.AddCommand(&cobra.Command{
+		Use:   "unlease [name] from [macaddr]",
+		Short: "Remove address lease with [macaddr] from subnet [name]",
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) != 3 {
+				log.Fatalf("%v requires 2 args", c.UseLine())
+			}
+			obj := &api.DhcpSubnet{}
+			if session.SetId(obj, args[0]) != nil {
+				log.Fatalf("Failed to parse ID %v for a dhcp subnet", args[0])
+			}
+			req, err := http.NewRequest("DELETE", session.UrlTo(obj, "lease", args[2]), nil)
+			if err != nil {
+				log.Fatalf("Failed to create HTTP request: %v", err)
+			}
+			resp, err := session.BasicRequest(req)
+			if err != nil {
+				log.Fatalf("Error deleting lease %s from %s: %v", args[2], args[0], err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode >= 300 {
+				log.Fatalf("Error deleting lease for %s: %s", args[0], resp.Status)
+			}
+			fmt.Printf("Deleted lease %s in %s", args[2], args[0])
+		},
+	})
+	subnet.AddCommand(&cobra.Command{
 		Use:   "nextserver [name] is [address]",
 		Short: "Set the next-server parameter for subnet [name] to [address]",
 		Run: func(c *cobra.Command, args []string) {

--- a/go/rebar-dhcp/data.go
+++ b/go/rebar-dhcp/data.go
@@ -185,6 +185,22 @@ func (dt *DataTracker) DeleteBinding(subnetName, mac string) (error, int) {
 	return nil, http.StatusOK
 }
 
+func (dt *DataTracker) DeleteLease(subnetName, mac string) (error, int) {
+	lsubnet := dt.Subnets[subnetName]
+	if lsubnet == nil {
+		return errors.New("Subnet Not Found"), http.StatusNotFound
+	}
+
+	b := lsubnet.Leases[mac]
+	if b == nil {
+		return errors.New("Lease Not Found"), http.StatusNotFound
+	}
+
+	delete(lsubnet.Leases, mac)
+	dt.save_data()
+	return nil, http.StatusOK
+}
+
 func (dt *DataTracker) SetNextServer(subnetName string, ip net.IP, nextServer NextServer) (error, int) {
 	lsubnet := dt.Subnets[subnetName]
 	if lsubnet == nil {


### PR DESCRIPTION
This adds an unlease action for DHCP leases.  This can be helpful in debugging and resetting environments.

Fix provisioner bootenvs that were missing use-proxy as a required variable.

Update the build containers script to work with the MAC cross-compile requirements.