### PR TITLE
IPMI wanted version

### DIFF
--- a/core/barclamps/ipmi.yml
+++ b/core/barclamps/ipmi.yml
@@ -315,6 +315,8 @@ roles:
     requires:
       - ipmi-discover
     wants-attribs:
+      - ipmi-wanted-version
+      - ipmi-firmware-history
       - ipmi-enable
       - ipmi-firmware-rev
       - ipmi-device-id
@@ -323,14 +325,9 @@ roles:
       - ipmi-product-id
       - provisioner-webservers
     attribs:
-      - name: ipmi-firmware-applied
-        map: 'ipmi/firmware_updated'
-        description: "Whether a IPMI update was applied to this system"
-      - name: ipmi-firmware-applicable-version
-        map: 'ipmi/firmware_applicable_version'
-        description: 'The IPMI version that is applicable to this system.'
-      - name: ipmi-firmware-applicable-package
-        map: 'ipmi/firmware_applicable_package'
+      - name: ipmi-firmware-applicable
+        map: 'ipmi/firmware_applicable'
+        description: 'The IPMI versions that are applicable to this system. (JSON)'
       - name: ipmi-firmware-list
         description: "List of firmware updates available"
         map: 'ipmi/firmware_updates'
@@ -379,8 +376,11 @@ roles:
             ipmi-firmware-rev: "2.32"
             script: |
               #!/usr/bin/env bash
+              if [[ $forceit == true ]] ; then
+                  FORCE="-f"
+              fi
               chmod 755 "$package"
-              "$package" -q -r
+              "$package" -q -r $FORCE
               case $? in
                   0)  # No reboot required.
                       exit 0;;
@@ -410,8 +410,11 @@ roles:
             ipmi-firmware-rev: "2.40"
             script: |
               #!/usr/bin/env bash
+              if [[ $forceit == true ]] ; then
+                  FORCE="-f"
+              fi
               chmod 755 "$package"
-              "$package" -q -r
+              "$package" -q -r $FORCE
               case $? in
                   0)  # No reboot required.
                       exit 0;;
@@ -537,4 +540,14 @@ attribs:
     schema:
       type: bool
       required: true
+  - name: ipmi-wanted-version
+    map: 'ipmi/wanted-version'
+    description: 'The desired version of the IPMI subsystem.'
+    default: "latest"
+    schema:
+      type: str
+      required: true
+  - name: ipmi-firmware-history
+    map: 'ipmi/firmware_history'
+    description: "IPMI update history of applied updates"
 

--- a/core/script/roles/ipmi-flash/01-stub.sh
+++ b/core/script/roles/ipmi-flash/01-stub.sh
@@ -7,6 +7,7 @@ PARAMS['ipmi-product-id']='rebar_wall/ipmi/bmcinfo/product_id'
 PARAMS['ipmi-device-id']='rebar_wall/ipmi/bmcinfo/device_id'
 PARAMS['ipmi-device-rev']='rebar_wall/ipmi/bmcinfo/device_rev'
 
+wanted_version=$(read_attribte "ipmi/wanted-version")
 
 rev_lt() {
     # $1 = current firmware rev
@@ -27,12 +28,16 @@ for v in "${!PARAMS[@]}"; do
     VALUES["$v"]="$(read_attribute "${PARAMS[$v]}")"
 done
 
-found_one=false
-found_one_version=""
-found_one_package=""
+packages=()
+entries=()
+versions=()
+applicable=()
+forcing=()
+
 while read -r entry; do
-    match=true
     found=true
+    isapplicable=true
+    forceit=false
     package="$(jq -r -c '.["package"]' <<< "$entry")"
     printf "Testing firmware update %s\n" "$package"
     for v in "${!PARAMS[@]}"; do
@@ -40,45 +45,96 @@ while read -r entry; do
         [[ ! $val || $val = null ]] && continue
         case $v in
             'ipmi-firmware-rev')
-                printf "Testing firmware version '%s' against '%s'\n" "$v" "$val"
-                version=$val
-                if ! rev_lt "${VALUES[$v]}" "$val"; then
-                    match=false
+                printf "Testing firmware version '%s' against '%s'\n" "${VALUES[$v]}" "$val"
+                version="$val"
+
+                if [[ "$wanted_version" == "latest" ]] ; then
+                    if ! rev_lt "${VALUES[$v]}" "$version"; then
+                        isapplicable=false
+                    fi
+                else
+                    if [[ "$wanted_version" == "$version" ]] ; then
+                        if [[ "${VALUES[$v]}" == "$version" ]] ; then
+                            # already at the desired version
+                            isapplicable=false
+                        else
+                            # Else - we need to apply the package.
+                            isapplicable=true
+                            # if we have to go backwards force it
+                            if ! rev_lt "${VALUES[$v]}" "$version"; then
+                                forceit=true
+                            fi
+                        fi
+                    else
+                        # Isn't the desired version - skip it.
+                        isapplicable=false
+                        # We could test less than and walk up to wanted.  ???
+                    fi
                 fi;;
             *)
                 printf "Checking that '%s' value '%s' = '%s'\n" "$v" "$val" "${VALUES[$v]}"
-                if [[ $val != ${VALUES[$v]} ]]; then
+                if [[ $val != ${VALUES[$v]} ]] ; then
                     found=false
                     break
                 fi
         esac
     done
     if [[ $found = true ]]; then
-        found_one=true
-        found_one_version=$version
-        found_one_package=$package
-        if [[ $match = true ]]; then
+        versions+=("$version")
+        packages+=("$package")
+        applicable+=($isapplicable)
+        forcing+=(forceit)
+        entries+=("$entry")
+        if [[ $isapplicable = true ]]; then
             printf 'Package %s is valid for this system\n' "$package"
-            break
         else
             printf 'Package %s is valid for this system, but old or current.  Keep looking ...\n' "$package"
         fi
     else
-        match=false
         printf 'Package %s is not valid for this system\n' "$package"
     fi
 done < <(jq -r -c '.[]' <<< "$(read_attribute 'ipmi/firmware_updates')")
-if [[ $found_one = false ]]; then
+
+if [[ ${#packages[@]} = 0 ]]; then
     echo "No IPMI firmware update found for this system"
     exit 0
 fi
-verson=$found_one_version
-package=$found_one_package
-write_attribute 'ipmi/firmware_applicable_version' "$version"
-write_attribute 'ipmi/firmware_applicable_package' "$package"
-if [[ $match = false ]]; then
-     write_attribute 'ipmi/firmware_updated' false
-    echo "IPMI firmware $package already up to date"
+
+isapplicable=false
+package=""
+entry=""
+matchwanted=false
+if [[ $wanted_version == ${VALUES['ipmi-firmware-rev']} ]] ; then
+    matchwanted=true
+fi
+
+json="{"
+COMMA=""
+for index in "${!packages[@]}"
+do
+    # Record first appliable package to apply
+    if [[ $isapplicable == false && ${applicable[$index]} == true ]] ; then
+        package=${packages[$index]}
+        entry=${entries[$index]}
+        isapplicable=true
+        forceit=${forcing[$index]}
+    fi
+    if [[ ${versions[$index]} == ${wanted_version} || $wanted_version == "latest" ]] ; then
+        matchwanted=true
+    fi
+    json="$json$COMMA { \"package\": \"${packages[$index]}\", \"verison\": \"${versions[$index]}\", \"applicable\": ${applicable[$index]} }"
+    COMMA=","
+done
+json="$json }"
+write_attribute 'ipmi/firmware_applicable' "$json"
+
+if [[ $isapplicable = false && $matchwanted = false ]] ; then
+    echo "IPMI firmware can't update to wanted version"
+    exit -1
+fi
+
+if [[ $isapplicable = false ]]; then
+    echo "IPMI firmware already up to date"
     exit 0
 fi
 
@@ -96,6 +152,8 @@ if ! sha256sum -c <(printf '%s  %s' "$(jq -r '.["package-sha256sum"]' <<< "$entr
     echo "Invalid checksum for $package"
     exit 1
 fi
-write_attribute 'bios/firmware_updated' true
+history=$(read_attribute 'ipmi/firmware_history')
+history="$history$(date) $version $package\n"
+write_attribute 'ipmi/firmware_history' "$history"
 printf '%b' "$(jq -r '.script' <<< "$entry")" > update.sh
 . ./update.sh


### PR DESCRIPTION
This adds a history variable that tracks updates over time.
This adds the wanted_version variable that can be latest or a specific
version.  If the value is latest, the code will walk from youngest to
oldest applying the updates in order until the version is the "latest"
in the list. If a specific version is specified, only that version will
be specified.  If the version is less than the current version, a force
variable is set and the scripts are updated to use it.

One design choice that was punted for now is if the wanted_version
is say 10, and the current is 6 and we know about 8 and 10, we will
only apply 10.  There are cases where this is desired and then there
are cases where we want to apply 8 and then 10.