### PR TITLE
allow playbook body to be array instead of long string

### DIFF
--- a/core/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
+++ b/core/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
@@ -121,7 +121,10 @@ class BarclampRebar::AnsiblePlaybookJig < Jig
               file + ".yml"
             end
             f2 = File.open("#{piece_part}/#{type}/#{f}", "w")
-            f2.write(item["body"])
+            body = item["body"]
+            # allow body to be array for readability
+            body = body.join("\n") if body.kind_of?(Array)
+            f2.write(body)
             f2.close
           end
         end


### PR DESCRIPTION
small usability tweak that improves readability for when files get long (which they do quickly)