### PR TITLE
allow SYSTEM deployment to be proposed - needed for SSH key changes

### DIFF
--- a/core/rails/app/models/deployment.rb
+++ b/core/rails/app/models/deployment.rb
@@ -146,7 +146,7 @@ class Deployment < ActiveRecord::Base
   # Do this by changing its state from COMMITTED to PROPOSED.
   def propose
     Deployment.transaction do
-      raise "Cannot propose  a system deployment" if system?
+      # ALLOWING SYSTEM TO PROPOSE WILL HALT SYSTEM ACTION WHILE PROPOSED > raise "Cannot propose  a system deployment" if system?
       write_attribute("state",PROPOSED)
       save!
     end


### PR DESCRIPTION
there is danger here BUT we need to move this to "buyer beware" because we want to be able to set system noderoles.

I will make matching changes to the UX with appropriate warnings.

reviewed by @galthaus 