### PR TITLE
Add rebar-access content brackets around the ssh keys on

### DIFF
--- a/containers/cloudwrap/cloudwrap/waiter.rb
+++ b/containers/cloudwrap/cloudwrap/waiter.rb
@@ -182,9 +182,11 @@ loop do
         server.ssh("sudo -- service sshd restart")
         Tempfile.open("cloudwrap-keys") do |f|
           pubkeys = JSON.parse(`rebar deployments get system attrib rebar-access_keys`)
+          f.puts("### BEGIN GENERATED CONTENT")
           pubkeys['value'].each_value do |v|
             f.puts(v.strip)
           end
+          f.puts("### END GENERATED CONTENT")
           f.flush
           f.fsync
           server.scp(f.path,"/tmp/rebar_keys")
@@ -207,9 +209,11 @@ loop do
         log "Put keys to node"
         Tempfile.open("cloudwrap-keys") do |f|
           pubkeys = JSON.parse(`rebar deployments get system attrib rebar-access_keys`)
+          f.puts("### BEGIN GENERATED CONTENT")
           pubkeys['value'].each_value do |v|
             f.puts(v.strip)
           end
+          f.puts("### END GENERATED CONTENT")
           f.flush
           f.fsync
           begin

--- a/core/rails/app/models/attrib.rb
+++ b/core/rails/app/models/attrib.rb
@@ -282,6 +282,7 @@ class Attrib < ActiveRecord::Base
         end
         # Poke all the noderoles in this deployment that get data from this deployment role.
         to.noderoles.order("cohort ASC").each do |dnr|
+          poke(dnr)
           dnr.children.order("cohort ASC").each do |nr|
             next unless RoleRequireAttrib.find_by(role_id: nr.role_id, attrib_name: self.name)
             poke(nr)

--- a/deploy/compose/config-dir/provisioner/templates/centos-6.ks.tmpl
+++ b/deploy/compose/config-dir/provisioner/templates/centos-6.ks.tmpl
@@ -117,7 +117,9 @@ echo "$REBAR_UUID" > /etc/rebar-uuid
 
 mkdir -p /root/.ssh
 cat >/root/.ssh/authorized_keys <<EOF
+### BEGIN GENERATED CONTENT
 {{ range $key := .Param "rebar-access_keys" }}{{$key}}{{ end }}
+### END GENERATED CONTENT
 EOF
 echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config
 # Allow client to pass http proxy environment variables

--- a/deploy/compose/config-dir/provisioner/templates/centos-7.ks.tmpl
+++ b/deploy/compose/config-dir/provisioner/templates/centos-7.ks.tmpl
@@ -113,7 +113,9 @@ if [ ! -f "$rsyslog_dir/10-rebar-client.conf" ]; then
 fi
 mkdir -p /root/.ssh
 cat >/root/.ssh/authorized_keys <<EOF
+### BEGIN GENERATED CONTENT
 {{ range $key := .Param "rebar-access_keys" }}{{$key}}{{ end }}
+### END GENERATED CONTENT
 EOF
 echo "PermitRootLogin without-password" >> /etc/ssh/sshd_config
 echo "AcceptEnv http_proxy https_proxy no_proxy" >> /etc/ssh/sshd_config

--- a/deploy/compose/config-dir/provisioner/templates/net-post-install.sh.tmpl
+++ b/deploy/compose/config-dir/provisioner/templates/net-post-install.sh.tmpl
@@ -47,7 +47,9 @@ wget -q {{.Machine.Url}}/rebar_join.sh -O- > /target/etc/init.d/rebar_join
 mkdir -p /target/root/.ssh
 
 cat >/target/root/.ssh/authorized_keys <<EOF
+### BEGIN GENERATED CONTENT
 {{ range $key := .Param "rebar-access_keys" }}{{$key}}{{ end }}
+### END GENERATED CONTENT
 EOF
 
 echo "PermitRootLogin without-password" >> /target/etc/ssh/sshd_config

--- a/deploy/compose/config-dir/provisioner/templates/sledgehammer-control.sh.tmpl
+++ b/deploy/compose/config-dir/provisioner/templates/sledgehammer-control.sh.tmpl
@@ -51,7 +51,9 @@ cp /etc/gemrc /root/.gemrc
 
 mkdir -p /root/.ssh
 cat >/root/.ssh/authorized_keys <<EOF
+### BEGIN GENERATED CONTENT
 {{ range $key := .Param "rebar-access_keys" }}{{$key}}{{ end }}
+### END GENERATED CONTENT
 EOF
 
 # Mark us as alive.


### PR DESCRIPTION
install so that rebar-access script can accurately manage them.