### PR TITLE
consolidate CORS headers, add missing headers, remove duplicates

### DIFF
--- a/go/rebar-rev-proxy/proxy.go
+++ b/go/rebar-rev-proxy/proxy.go
@@ -95,6 +95,7 @@ func NewMultipleHostReverseProxy(reg Registry, tlsConfig *tls.Config) http.Handl
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		addCorsHeader(w, req)
 		(&httputil.ReverseProxy{
 			Director: func(req *http.Request) {
 				req.URL.Scheme = "https"

--- a/go/rebar-rev-proxy/rebar-rev-proxy.go
+++ b/go/rebar-rev-proxy/rebar-rev-proxy.go
@@ -50,11 +50,10 @@ func addCorsHeader(w http.ResponseWriter, req *http.Request) {
 	origin := req.Header.Get("Origin")
 	if origin != "" {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
-		w.Header().Set("Access-Control-Allow-Headers", "DR-AUTH-TOKEN,X-Requested-With,Content-Type,Cookie,Authorization,WWW-Authenticate") // If-Modified-Since,If-None-Match,
-		w.Header().Set("Access-Control-Allow-Headers", "DR-USER-TOKEN,X-Requested-With,Content-Type,Cookie,Authorization,WWW-Authenticate") // If-Modified-Since,If-None-Match,
+		w.Header().Set("Access-Control-Allow-Headers", "Origin,DR-USER-TOKEN,DR-AUTH-TOKEN,X-Requested-With,Content-Type,Cookie,Authorization,WWW-Authenticate, X-Return-Attributes") // If-Modified-Since,If-None-Match,
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
-		w.Header().Set("Access-Control-Expose-Headers", "DR-AUTH-TOKEN,WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin")
-		w.Header().Set("Access-Control-Expose-Headers", "DR-USER-TOKEN,WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin")
+		w.Header().Set("Access-Control-Expose-Headers", "DR-USER-TOKEN,DR-AUTH-TOKEN,WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin, X-Return-Attributes")
+		w.Header().Set("X-Frame-Options", "ALLOW-FROM "+origin)
 	}
 }
 


### PR DESCRIPTION
UX optimization uses the "X-Return-Attributes" header which should have been included in the CORS list.  

This change adds the missing field and does some minor cleanups.

There is a matching pull for REMOVING CORS from the RAILS API because it was redundant with the Revproxy CORS; however, that required having the api/license call also use CORS in the proxy.go routine.