### PR TITLE
Remote Rails CORS & Allow Attrib Writable

### DIFF
--- a/core/barclamps/cluster.yml
+++ b/core/barclamps/cluster.yml
@@ -46,18 +46,21 @@ roles:
         map: 'cluster/name'
         description: 'Name used for Cluster'
         default: 'default'
-        type: str
-        pattern: /^\[?[a-z]\]*/
+        schema:
+          type: str
+          pattern: /^\[?[a-z]\]*/
       - name: cluster-active-only
         map: 'cluster/active-only'
         description: 'Use addresses from Active NodeRoles only?'
         default: false
-        type: bool
+        schema:
+          type: bool
       - name: cluster-network
         map: 'cluster/network'
         description: 'Network used for Cluster'
         default: 'node-control-address'
-        type: str
+        schema:
+          type: str
       - name: cluster-addresses
         description: "All addresses of the Cluster nodes"
         map: 'cluster/addresses'
@@ -80,5 +83,6 @@ roles:
       - name: cluster-address
         map: 'cluster/address'
         description: 'IP of Node for Cluster'      
-        type: str
-        pattern: /\[?[0-9a-f:.]*\]?:?[0-9]*/
+        schema:
+          type: str
+          pattern: /\[?[0-9a-f:.]*\]?:?[0-9]*/

--- a/core/bin/barclamp_import
+++ b/core/bin/barclamp_import
@@ -258,6 +258,7 @@ class Barclamp < RebarProxy
       yml = File.join(path,"rebar.yml")
     end
     raise "No rebar.yml at #{path}" unless File.exists?(yml)
+    debug("Loading file #{yml}")
     settings = YAML.load_file(yml)
     settings['barclamp']['source_path'] = File.realpath(path)
     bc, res = REST.get("#{self.path}/#{settings['barclamp']['name']}")

--- a/core/bin/barclamp_import
+++ b/core/bin/barclamp_import
@@ -258,7 +258,7 @@ class Barclamp < RebarProxy
       yml = File.join(path,"rebar.yml")
     end
     raise "No rebar.yml at #{path}" unless File.exists?(yml)
-    debug("Loading file #{yml}")
+    debug("Loading parent file #{yml}")
     settings = YAML.load_file(yml)
     settings['barclamp']['source_path'] = File.realpath(path)
     bc, res = REST.get("#{self.path}/#{settings['barclamp']['name']}")
@@ -269,6 +269,7 @@ class Barclamp < RebarProxy
     end
     # Load child barclamps
     Dir.glob(File.join(path,"barclamps","*.yml")).each do |child_yml|
+      debug("Loading child file #{yml}")
       settings = YAML.load_file(child_yml)
       settings['barclamp']['source_path'] = path
       child, res = REST.get("#{self.path}/#{settings['barclamp']['name']}")

--- a/core/rails/app/controllers/application_controller.rb
+++ b/core/rails/app/controllers/application_controller.rb
@@ -369,23 +369,12 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  def cors_headers
-    access_control = {
-      'Access-Control-Allow-Origin' => request.headers["HTTP_ORIGIN"],
-      'Access-Control-Allow-Headers' => 'X-Requested-With,Content-Type,Cookie,Authorization,WWW-Authenticate', # If-Modified-Since,If-None-Match,
-      'Access-Control-Allow-Credentials' => true,
-      'Access-Control-Expose-Headers' => 'WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin'
-    }
-    access_control.each{ |k, v| response.headers[k] = v } if request.headers["HTTP_ORIGIN"]
-  end
-
   def digest_request?
     request.headers["HTTP_AUTHORIZATION"] && request.headers["HTTP_AUTHORIZATION"].starts_with?('Digest username=')
   end
 
   def digest_auth!
     u = nil
-    cors_headers
     authed = authenticate_or_request_with_http_digest(User::DIGEST_REALM) do |username|
       u = User.find_by!(username: username, system: false)
       session[:digest_user] = u.username
@@ -408,9 +397,9 @@ class ApplicationController < ActionController::Base
 
   #return true if we digest signed in
   def rebar_auth
-    Rails.logger.debug("peercert: #{request.headers["puma.socket"].peercert}")
-    Rails.logger.info("username header: #{request.headers["HTTP_X_AUTHENTICATED_USERNAME"]}")
-    Rails.logger.info("capability header: #{request.headers["HTTP_X_AUTHENTICATED_CAPABILITY"]}")
+    #Rails.logger.debug("peercert: #{request.headers["puma.socket"].peercert}")
+    Rails.logger.debug("username header: #{request.headers["HTTP_X_AUTHENTICATED_USERNAME"]}")
+    Rails.logger.debug("capability header: #{request.headers["HTTP_X_AUTHENTICATED_CAPABILITY"]}")
     case
     when !request.headers["HTTP_X_AUTHENTICATED_USERNAME"].nil?
       unless request.headers["puma.socket"].peercert ||

--- a/core/rails/app/controllers/docs_controller.rb
+++ b/core/rails/app/controllers/docs_controller.rb
@@ -20,13 +20,6 @@ class DocsController < ApplicationController
 
   # render licenses details for login
   def eula
-    access_control = {
-      'Access-Control-Allow-Origin' => request.headers["HTTP_ORIGIN"],
-      'Access-Control-Allow-Headers' => 'X-Requested-With,Content-Type,Cookie,Authorization,WWW-Authenticate', # If-Modified-Since,If-None-Match,
-      'Access-Control-Allow-Credentials' => true,
-      'Access-Control-Expose-Headers' => 'WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin'
-    }
-    access_control.each{ |k, v| response.headers[k] = v } if request.headers["HTTP_ORIGIN"]
     if params.has_key? :alive            
       render json: {}, status => :no_content
     else

--- a/core/rails/app/controllers/users_controller.rb
+++ b/core/rails/app/controllers/users_controller.rb
@@ -24,16 +24,6 @@ class UsersController < ApplicationController
   skip_before_filter :rebar_auth, :only => [:options]
   skip_before_filter :authenticate_user!, :only => [:options]
 
-  def cors_headers
-    access_control = {
-      'Access-Control-Allow-Origin' => request.headers["HTTP_ORIGIN"],
-      'Access-Control-Allow-Headers' => 'X-Requested-With,Content-Type,Cookie,Authorization,WWW-Authenticate', # If-Modified-Since,If-None-Match,
-      'Access-Control-Allow-Credentials' => true,
-      'Access-Control-Expose-Headers' => 'WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin'
-    }
-    access_control.each{ |k, v| response.headers[k] = v } if request.headers["HTTP_ORIGIN"]
-  end
-
   def digest
     if request.get? or request.post? or request.head?
       if request.headers["HTTP_ORIGIN"]
@@ -58,8 +48,6 @@ class UsersController < ApplicationController
 
   # CORS header method - not used for rev_proxy
   def options
-    cors_headers
-    response.headers['Access-Control-Allow-Methods'] = 'GET,POST,PUT,DELETE,OPTIONS,PATCH,HEAD'
     render :nothing => true, :status => :no_content
   end
 

--- a/core/rails/app/models/attrib.rb
+++ b/core/rails/app/models/attrib.rb
@@ -230,8 +230,31 @@ class Attrib < ActiveRecord::Base
   end
 
   def make_writable_if_schema
-    return if schema.nil? || schema == ""
-    update(writable: true)
+    # if the schema is set, assume writable
+    # if not, set the schema reasable, but do not make writable!
+    if schema.nil? || schema == ""
+      if default["value"].nil?
+        update(schema: {type: "string", required: false})
+      elsif ["true", "false"].include? default["value"]
+        update(schema: {type: "bool", required: false})
+      elsif ["true", "false"].include? default["value"].to_s
+        update(schema: {type: "bool", required: false})
+      elsif default["value"].kind_of?(Integer)
+        update(schema: {type: "int", required: false})
+      elsif default["value"].kind_of?(Hash)
+        update(schema: {type: "map", required: false, mapping: {:"=" => {type: "str"}}})
+      elsif default["value"].kind_of?(Array)
+        update(schema: {type: "seq", required: false, sequence: {type: "str"}})
+      elsif default["value"].start_with? "{"
+        update(schema: {type: "map", required: false, mapping: {:"=" => {type: "str"}}})
+      elsif default["value"].start_with? "["
+        update(schema: {type: "seq", required: false, sequence: {type: "str"}})
+      else
+        update(schema: {type: "string", required: false})
+      end
+    else
+      update(writable: true)
+    end
   end
 
   def __set_and_save(to_orig, value, target=:system)

--- a/core/rails/app/models/attrib.rb
+++ b/core/rails/app/models/attrib.rb
@@ -230,31 +230,8 @@ class Attrib < ActiveRecord::Base
   end
 
   def make_writable_if_schema
-    # if the schema is set, assume writable
-    # if not, set the schema reasable, but do not make writable!
-    if schema.nil? || schema == ""
-      if default["value"].nil?
-        update(schema: {type: "string", required: false})
-      elsif ["true", "false"].include? default["value"]
-        update(schema: {type: "bool", required: false})
-      elsif ["true", "false"].include? default["value"].to_s
-        update(schema: {type: "bool", required: false})
-      elsif default["value"].kind_of?(Integer)
-        update(schema: {type: "int", required: false})
-      elsif default["value"].kind_of?(Hash)
-        update(schema: {type: "map", required: false, mapping: {:"=" => {type: "str"}}})
-      elsif default["value"].kind_of?(Array)
-        update(schema: {type: "seq", required: false, sequence: {type: "str"}})
-      elsif default["value"].start_with? "{"
-        update(schema: {type: "map", required: false, mapping: {:"=" => {type: "str"}}})
-      elsif default["value"].start_with? "["
-        update(schema: {type: "seq", required: false, sequence: {type: "str"}})
-      else
-        update(schema: {type: "string", required: false})
-      end
-    else
-      update(writable: true)
-    end
+    return if schema.nil? || schema == ""
+    update(writable: true)
   end
 
   def __set_and_save(to_orig, value, target=:system)

--- a/core/rails/app/models/barclamp.rb
+++ b/core/rails/app/models/barclamp.rb
@@ -238,7 +238,7 @@ class Barclamp < ActiveRecord::Base
           attrib_ui_renderer = attrib['ui_renderer'] || Attrib::UI_RENDERER
           attrib_map = attrib['map'] || attrib_name.gsub("-","/")
           attrib_default = attrib['default']
-          attrib_writable = !!attrib['schema']
+          attrib_writable = attrib['writable'] || !!attrib['schema']
           a = attrib_type.find_or_create_by!(name: attrib_name)
           a.update_attributes!(description: attrib_desc,
                                map: attrib_map,

--- a/core/rails/config/application.rb
+++ b/core/rails/config/application.rb
@@ -42,7 +42,7 @@ module Rebar
       config.action_controller.perform_caching             = true
       config.action_view.cache_template_loading            = true
       config.active_support.deprecation = :notify
-      config.action_controller.allow_forgery_protection    = true
+      config.action_controller.allow_forgery_protection    = false
       config.eager_load = true    
       config.log_level = :info
       config.rebar.devmode = false

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -30,6 +30,7 @@ install-*.log
 /compose/tag
 /compose/data-dir
 /compose/docker-compose-common.dev
+/compose/galaxy
 
 /containers/tree_bag
 

--- a/go/build-rebar.sh
+++ b/go/build-rebar.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if ! which glide &>/dev/null; then
+    echo "Please install Glide! https://glide.sh"
+    break
+fi
+
 [[ $DEBUG ]] && set -x
 
 # Requires GOPATH to be set and will use it


### PR DESCRIPTION
Related to #150 

Remove the redundant CORS headers from the RAILS apps.  They were conflicting with the Revproxy in confusing ways.

To make attrib render correctly in the UX, we need to set the schema for all attribs.  That means that we CANNOT assume that schema = writable.  This change will allow us to set writable: false for some attribs.  

There are some other minor cleanups.