### PR TITLE
Ansible does not like passing NULL variables

### DIFF
--- a/core/rails/app/models/barclamp.rb
+++ b/core/rails/app/models/barclamp.rb
@@ -208,7 +208,6 @@ class Barclamp < ActiveRecord::Base
           Rails.logger.info("Making #{r.name} depend on #{rr}")
           RoleRequire.find_or_create_by!(role_id: r.id, requires: rr)
         end
-        RoleRequire.where(role_id: ar.id).delete_all  # cleanup before insert
         attaches.each do |ar_name|
           ar = Role.find_by!(name: ar_name)
           Rails.logger.info("Making #{r.name} depend on #{ar.name}")

--- a/core/rails/app/models/barclamp.rb
+++ b/core/rails/app/models/barclamp.rb
@@ -203,15 +203,18 @@ class Barclamp < ActiveRecord::Base
                              leaverunlog: flags.include?('leaverunlog'),
                              metadata:    role_metadata,
                              icon:        icon)
+        RoleRequire.where(role_id: r.id).delete_all  # cleanup before insert
         prerequisites.each do |rr|
           Rails.logger.info("Making #{r.name} depend on #{rr}")
           RoleRequire.find_or_create_by!(role_id: r.id, requires: rr)
         end
+        RoleRequire.where(role_id: ar.id).delete_all  # cleanup before insert
         attaches.each do |ar_name|
           ar = Role.find_by!(name: ar_name)
           Rails.logger.info("Making #{r.name} depend on #{ar.name}")
           RoleRequire.find_or_create_by!(role_id: ar.id, requires: r.name)
         end
+        RolePreceed.where(role_id: r.id).delete_all  # cleanup before insert
         role_preceeds.each do |p_name|
           Rails.logger.info("Making #{r.name} preceed #{p_name}")
           RolePreceed.find_or_create_by!(role_id: r.id, preceeds: p_name)

--- a/core/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
+++ b/core/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
@@ -73,6 +73,7 @@ class BarclampRebar::AnsiblePlaybookJig < Jig
   end
 
   def run(nr,data)
+
     # pull metadata from barclamp
     role_yaml = nr.role.barclamp.metadata || {}
     # override with role metadata
@@ -184,6 +185,9 @@ class BarclampRebar::AnsiblePlaybookJig < Jig
       value = get_value(nr.node, nr, data, am['name'])
       set_value(data, am['path'], value)
     end if role_yaml['attribute_map']
+
+    # we don't want null values the data set because Ansible prefers them to just be undefined (missing)
+    data.delete_if {|key, value| value.nil? }
 
     File.open("#{rundir}/rebar.json", 'w') do |f|
       JSON.dump(data,f)

--- a/deploy/compose/docker-compose-common.yml
+++ b/deploy/compose/docker-compose-common.yml
@@ -68,6 +68,7 @@ rebar_api:
     - ./data-dir/bin:/usr/local/dev/bin
     # development mapping for playbook authors
     # - ../../digitalrebar-workloads/:/var/cache/rebar/ansible_playbook/k8
+    # - ./galaxy:/etc/ansible/roles/  # reminder: sudo chown root:root galaxy
   env_file:
     - ./common.env
     - ./access.env


### PR DESCRIPTION
This removes the null variables from the TOP level of the passed attributes.  That allows those to be undefined instead of null.

In the future, it could be that we want to look at "required" flag instead of assuming all null are removed.

Also, prune relationships on barclamp import.