### PR TITLE
Node roles in the proposed state should not be poked.

### DIFF
--- a/core/rails/app/models/attrib.rb
+++ b/core/rails/app/models/attrib.rb
@@ -217,7 +217,7 @@ class Attrib < ActiveRecord::Base
   #
   def poke(nr)
     Rails.logger.info("Attrib: #{self.name} poking NodeRole #{nr.name}")
-    nr.send(:block_or_todo)
+    nr.send(:block_or_todo) if !nr.proposed?
   end
 
   private


### PR DESCRIPTION
They will get poked when the deployment or node are committed.