### PR TITLE
Matrix View, view tweaks for UX

### DIFF
--- a/core/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
+++ b/core/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
@@ -295,14 +295,8 @@ class BarclampRebar::AnsiblePlaybookJig < Jig
     nr.update!(wall: new_wall)
 
     # allows a nooprole to coerce the icon for a node
-    if nr.role.replace_node_icon
-      Node.transaction do
-        n = nr.node
-        n.icon = nr.role.icon
-        n.save!
-      end
-    end
-    
+    Jig.node_icon nr
+
     # Clean up after ourselves.
     system("rm -rf '#{rundir}'")
     system("rm -f '#{role_cache_dir}/#{role_yaml['playbook_path']}/#{role_file}'") if clean_role_file

--- a/core/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
+++ b/core/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
@@ -294,6 +294,15 @@ class BarclampRebar::AnsiblePlaybookJig < Jig
     new_wall = {}
     nr.update!(wall: new_wall)
 
+    # allows a nooprole to coerce the icon for a node
+    if nr.role.replace_node_icon
+      Node.transaction do
+        n = nr.node
+        n.icon = nr.role.icon
+        n.save!
+      end
+    end
+    
     # Clean up after ourselves.
     system("rm -rf '#{rundir}'")
     system("rm -f '#{role_cache_dir}/#{role_yaml['playbook_path']}/#{role_file}'") if clean_role_file

--- a/core/rails/app/models/deployment_role.rb
+++ b/core/rails/app/models/deployment_role.rb
@@ -38,7 +38,12 @@ class DeploymentRole < ActiveRecord::Base
   def as_json(args = nil)
     args ||= {}
     args[:except] = [ :proposed_data, :committed_data, :wall, :notes]
-    super(args).merge({"proposed" => proposed?})
+    o = super(args)
+    o['proposed'] = self.proposed?
+    o['_proposed'] = self.proposed?
+    o['_role_name'] = self.role.name
+    o['_role_icon'] = self.role.icon
+    o
   end
 
   # convenience methods

--- a/core/rails/app/models/jig.rb
+++ b/core/rails/app/models/jig.rb
@@ -56,6 +56,18 @@ class Jig < ActiveRecord::Base
     Jig.where(:name=>jig, :active=>true).length > 0
   end
 
+  # allows a nooprole to coerce the icon for a node
+  def self.node_icon(nr)
+    if nr.state == 0 and nr.role.replace_node_icon
+      Node.transaction do
+        n = nr.node
+        n.icon = nr.role.icon
+        n.save!
+      end
+    end
+
+  end
+
   # OVERRIDE with actual methods
   def delete_node(node)
     Rails.logger.debug("jig.delete_node(#{node.name}) not implemented for #{self.class}.  This may be OK")
@@ -119,18 +131,11 @@ end
 class NoopJig < Jig
 
   def stage_run(nr)
+    Jig.node_icon nr
     return nr.all_my_data
   end
 
   def run(nr,data)
-    # allows a nooprole to coerce the icon for a node
-    if nr.role.replace_node_icon
-      Node.transaction do
-        n = nr.node
-        n.icon = nr.role.icon
-        n.save!
-      end
-    end
     return true
   end
 

--- a/core/rails/app/models/node_role.rb
+++ b/core/rails/app/models/node_role.rb
@@ -174,7 +174,10 @@ class NodeRole < ActiveRecord::Base
     args ||= {}
     args[:except] = [ :proposed_data, :committed_data, :sysdata, :wall, :notes ]
     args[:methods] = :node_error
-    super(args)
+    o = super(args)
+    o['_role_name'] = self.role.name
+    o['_role_icon'] = self.role.icon
+    o
   end
 
   def self.state_name(state)

--- a/core/rails/config/routes.rb
+++ b/core/rails/config/routes.rb
@@ -91,7 +91,6 @@ Rebar::Application.routes.draw do
     get 'import(/:id)'  => 'support#import', :as => :utils_import
     get 'upload/:id'    => 'support#upload', :as => :utils_upload
     get 'restart/:id'   => 'support#restart', :as => :restart
-    get 'digest'        => "support#digest"
     get 'fail'          => "support#fail"
     get 'settings'      => "support#settings", :as => :utils_settings
     put 'settings(/:id/:value)' => "support#settings_put", :as => :utils_settings_put
@@ -118,6 +117,7 @@ Rebar::Application.routes.draw do
         scope 'status' do
           get "nodes(/:id)" => "nodes#status", :as => :nodes_status
           get "deployments(/:id)" => "deployments#status", :as => :deployments_status
+          get "matrix(/:id)" => "deployments#matrix", :as => :deployments_matrix
           get "heartbeat" => "support#heartbeat", :as => :heartbeat_status
           get "inventory(/:id)" => "inventory#index"
           match "active" => "node_roles#status", via: [:get, :put]


### PR DESCRIPTION
Primarily this adds a new view to support the UX/VX optimization.  The new view /api/status/matrix is NOT part of the API so it does not have a contract.  The is designed strictly to improve render for the Matrix view so that we do not have to pre-fetch so much data before rendering.

Also, minor adds to the node_roles and deployment_roles to prevent extra look ups in roles by adding role name and icon.  These fields were prefixed with _ to show they are not part of the model.  We may want to use that pattern more broadly when we denormalize the API model.  The denormalization is useful.

Also included attempt to fix #169 - needs more testing but not harmful.