### PR TITLE
add 7.3.1611 centos

### DIFF
--- a/deploy/tasks/compose.yml
+++ b/deploy/tasks/compose.yml
@@ -69,7 +69,7 @@
     when: "'--provisioner' in dr_services and not local_isos.stat.exists"
 
   - name: download Centos ISO (SLOW, see https://github.com/digitalrebar/digitalrebar/tree/master/deploy/containers/provisioner/update-nodes/bootenvs)
-    get_url: url=http://mirrors.kernel.org/centos/7.2.1511/isos/x86_64/CentOS-7-x86_64-Minimal-1511.iso dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/CentOS-7-x86_64-Minimal-1511.iso" checksum="sha256:f90e4d28fa377669b2db16cbcb451fcb9a89d2460e3645993e30e137ac37d284"
+    get_url: url=http://mirrors.kernel.org/centos/7.3.1611/isos/x86_64/CentOS-7-x86_64-Minimal-1611.iso dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/CentOS-7-x86_64-Minimal-1511.iso" checksum="sha256:27bd866242ee058b7a5754e83d8ee8403e216b93d130d800852a96f41c34d86a"
     when: "'--provisioner' in dr_services and not local_isos.stat.exists"
 
   - name: Make code dirs


### PR DESCRIPTION
From Gitter: 
Greg O @gregoryo2008_twitter 02:20
Okay I'm giving Rebar a go, and from the quickstart initial script I get errors because of Centos versions. To fix, I manually changed tasks/compose.yml to get 7.3.1611 instead of 7.2.1511 (since it's now gone), and updated the checksum.