### PR TITLE
Fix stupid single-char typo in supermicro_configure

### DIFF
--- a/core/rails/app/models/barclamp_bios/supermicro_configure.rb
+++ b/core/rails/app/models/barclamp_bios/supermicro_configure.rb
@@ -31,7 +31,7 @@ class BarclampBios::SupermicroConfigure < BarclampBios::Configure
     end
     bin_path = "/usr/local/bin/sum"
     unless File.exists?(bin_path) && File.executable?(bin_path)
-      Dir.mktempdir do |dir|
+      Dir.mktmpdir do |dir|
         Dir.chdir(dir) do
           unless system "tar xzf #{archive_path}"
             raise "Failed to extract #{archive_path}"


### PR DESCRIPTION
It was preventing the supermicro-configure role from extracting the
sum binary in the on_proposed hook.