### PR TITLE
Review only -- Add extensible support using external tools

### DIFF
--- a/containers/rebar-api/entrypoint.d/07-explode-supermicro-update-manager.sh
+++ b/containers/rebar-api/entrypoint.d/07-explode-supermicro-update-manager.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+archive_path=/opt/tools/sum_1.6.0_Linux_x86_64_20160128.tar.gz
+bin_path=/opt/tools/bin/sum
+if [[ -x $bin_path ]]; then
+    echo "Supermicro Update Manager already installed"
+elif ! [[ -f $archive_path ]]; then
+    echo "Missing $archive_path"
+    echo "Will not try to install Supermicro Update Manager"
+else
+    tmpdir=$(mktemp -d "/tmp/sum-XXXXX")
+    (
+        cd "$tmpdir"
+        tar xzf "$archive_path"
+        mkdir -p /opt/tools/bin
+        cp */sum /opt/tools/bin
+    )
+    rm -rf $tmpdir
+    if ! [[ -x $bin_path ]]; then
+        echo "Failed to extract supermicro update manager binary"
+        sleep 300
+        exit 1
+    fi
+fi

--- a/core/rails/app/models/barclamp_bios/supermicro.rb
+++ b/core/rails/app/models/barclamp_bios/supermicro.rb
@@ -28,7 +28,7 @@ class BarclampBios::Supermicro < BarclampBios::Driver
   def initialize(node, nr)
     super(node, nr)
     @ipmi = @node.hammers.find_by!(name: 'ipmi')
-    @sum = "/usr/local/bin/sum"
+    @sum = "/opt/tools/bin/sum"
     unless File.executable?(@sum)
       raise "SuperMicro Update Manager not installed at #{@sum}"
     end
@@ -123,7 +123,7 @@ class BarclampBios::Supermicro < BarclampBios::Driver
   end
 
   def sum(cmd)
-    res = %x{/usr/local/bin/sum -u #{@ipmi.username} -p #{@ipmi.authenticator} -i #{@ipmi.endpoint} #{cmd}}
+    res = %x{/opt/tools/bin/sum -u #{@ipmi.username} -p #{@ipmi.authenticator} -i #{@ipmi.endpoint} #{cmd}}
     status = $?.exitstatus
     if status == 80
       # License not activated.  Activate it and try again.

--- a/core/rails/app/models/barclamp_bios/supermicro_configure.rb
+++ b/core/rails/app/models/barclamp_bios/supermicro_configure.rb
@@ -23,30 +23,6 @@
 
 class BarclampBios::SupermicroConfigure < BarclampBios::Configure
 
-  def on_proposed(nr)
-    sum_archive = Attrib.get('bios-sum-archive',nr)
-    archive_path = "/opt/digitalrebar/#{sum_archive}"
-    unless File.exists?(archive_path)
-      raise "Missing Supermicro Update Manager utility (#{archive_path})"
-    end
-    bin_path = "/usr/local/bin/sum"
-    unless File.exists?(bin_path) && File.executable?(bin_path)
-      Dir.mktmpdir do |dir|
-        Dir.chdir(dir) do
-          unless system "tar xzf #{archive_path}"
-            raise "Failed to extract #{archive_path}"
-          end
-          ents = Dir.glob("*/sum")
-          if ents.length != 1
-            raise "Failed to extract a unique sum binary( #{ents} )"
-          end
-          system("cp #{ents[0]} /usr/local/bin")
-        end
-        system("rm -rf #{dir}/*")
-      end
-    end
-  end
-
   def do_transition(nr, data)
     @driver = BarclampBios::Supermicro.new(nr.node, nr)
     super(nr,data)

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -27,6 +27,7 @@ install-*.log
 /compose/config-dir/consul/server-advertise.json
 /compose/config-dir/rev-proxy/saml-dir/idpcert.crt
 /compose/config-dir/webproxy/squid.user.conf
+/compose/config-dir/tools
 /compose/tag
 /compose/data-dir
 /compose/docker-compose-common.dev

--- a/deploy/compose/docker-compose-common.yml
+++ b/deploy/compose/docker-compose-common.yml
@@ -7,6 +7,7 @@ consul:
     - ./config-dir/consul/server-advertise.json:/etc/consul.d/server-advertise.json
     - ./data-dir/consul/:/tmp/consul/
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -18,6 +19,7 @@ trust_me:
   volumes:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -30,6 +32,7 @@ postgres:
     - ./config-dir/postgres/initdb.d:/docker-entrypoint-initdb.d
     - ./data-dir/postgresql/:/var/lib/postgresql/
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -41,6 +44,7 @@ webproxy:
   volumes:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -52,6 +56,7 @@ goiardi:
     - ./data-dir/goiardi:/var/cache/goiardi
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -66,6 +71,7 @@ rebar_api:
     - ./config-dir/api/config:/opt/digitalrebar/core/config
     - ~/.cache/digitalrebar/tftpboot:/tftpboot
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
     # development mapping for playbook authors
     # - ../../digitalrebar-workloads/:/var/cache/rebar/ansible_playbook/k8
     # - ./galaxy:/etc/ansible/roles/  # reminder: sudo chown root:root galaxy
@@ -80,6 +86,7 @@ ntp:
   restart: always
   volumes:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -91,6 +98,7 @@ cloudwrap:
   volumes:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
     # debugging maps
     # - ../../containers/cloudwrap/cloudwrap/api.rb:/opt/cloudwrap/api.rb
     # - ../../containers/cloudwrap/cloudwrap/common.rb:/opt/cloudwrap/common.rb
@@ -105,6 +113,7 @@ dns:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./config-dir/bind/named.conf:/etc/bind/named.conf.tmpl
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -116,6 +125,7 @@ dhcp:
   volumes:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -129,6 +139,7 @@ provisioner:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ~/.cache/digitalrebar/tftpboot:/tftpboot
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -141,6 +152,7 @@ logging:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./data-dir/node-logs:/var/log/nodes
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -192,6 +204,7 @@ forwarder:
   volumes:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
 
@@ -209,6 +222,7 @@ revproxy:
     - ./config-dir/rev-proxy/db-store.json:/etc/rev-proxy/db-store.json
     - ./config-dir/rev-proxy/saml-dir:/etc/rev-proxy/saml-dir
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env
@@ -225,6 +239,7 @@ rule-engine:
   volumes:
     - ./config-dir/consul/client-default.json:/etc/consul.d/default.json
     - ./data-dir/bin:/usr/local/dev/bin
+    - ./config-dir/tools:/opt/tools
   env_file:
     - ./common.env
     - ./access.env


### PR DESCRIPTION
Previous methods of adding external tools for use by the containers was
rather ad-hoc.  This standardizes it that all tool distribution
files (.zip, .tar.gz, etc) should be placed in
deploy/compose/config-dir/tools, and that any tool binaries (sum, etc.)
should be placed in deploy/compose/config-dir/tools/bin.
deploy/compose/config-dir/tools will be mapped into the containers at
/opt/tools.

The primary user of this functionality is Supermicro remote BIOS
configuration support