### PR TITLE
add tenant support for multideploy, fix provider bug

### DIFF
--- a/deploy/workloads/cluster/deploy-001.json
+++ b/deploy/workloads/cluster/deploy-001.json
@@ -13,6 +13,7 @@
     "provisioner-target_os": "ubuntu-16.04"
   },
   "name": "cluster01",
+  "tenant": "cluster01",
   "public_keys": {
     "cluster01": "ssh-rsa AAAAB..... user@example.com"
   },

--- a/deploy/workloads/cluster/deploy-002.json
+++ b/deploy/workloads/cluster/deploy-002.json
@@ -13,6 +13,7 @@
     "provisioner-target_os": "ubuntu-16.04"
   },
   "name": "cluster02",
+  "tenant": "cluster02",
   "public_keys": {
     "cluster02": "ssh-rsa AAAAB..... user@example.com"
   },


### PR DESCRIPTION
providers were not working correctly for fresh installs.

added tenant detection and addition
that required replacing tenant with tenant_id (we do not look up tenant in deployment, ID is required)

At this point, the script will 
1) add provider from ~/.dr_info (if missing from system)
2) add tenant if included in file and new
3) replace tenant with tenant_id
4) create the deployment

DOES NOT WORK if the deployment exists.  In that case, use --destroy and retry!