### PR TITLE
Update URL's for Ubuntu 16.04 to reference 16.04.2

### DIFF
--- a/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-16.04.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-16.04.json
@@ -5,9 +5,9 @@
         "Name": "ubuntu-16.04",
         "Family": "ubuntu",
         "Version": "16.04",
-        "IsoFile": "ubuntu-16.04.1-server-amd64.iso",
-        "IsoUrl": "http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.1-server-amd64.iso",
-        "IsoSha256": "29a8b9009509b39d542ecb229787cdf48f05e739a932289de9e9858d7c487c80"
+        "IsoFile": "ubuntu-16.04.2-server-amd64.iso",
+        "IsoUrl": "http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.2-server-amd64.iso",
+        "IsoSha256": "737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535"
     },
     "Kernel": "install/netboot/ubuntu-installer/amd64/linux",
     "Initrds": [ "install/netboot/ubuntu-installer/amd64/initrd.gz" ],

--- a/deploy/tasks/compose.yml
+++ b/deploy/tasks/compose.yml
@@ -65,7 +65,7 @@
     when: "'--provisioner' in dr_services and local_isos.stat.exists"
 
   - name: download Ubuntu ISO (SLOW, see https://github.com/digitalrebar/digitalrebar/tree/master/deploy/containers/provisioner/update-nodes/bootenvs)
-    get_url: url=http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.1-server-amd64.iso dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/ubuntu-16.04.1-server-amd64.iso" checksum="sha256:29a8b9009509b39d542ecb229787cdf48f05e739a932289de9e9858d7c487c80"
+    get_url: url=http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.2-server-amd64.iso dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/ubuntu-16.04.1-server-amd64.iso" checksum="sha256:737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535"
     when: "'--provisioner' in dr_services and not local_isos.stat.exists"
 
   - name: download Centos ISO (SLOW, see https://github.com/digitalrebar/digitalrebar/tree/master/deploy/containers/provisioner/update-nodes/bootenvs)

--- a/go/provisioner-mgmt/bootenvs/ubuntu-16.04.json
+++ b/go/provisioner-mgmt/bootenvs/ubuntu-16.04.json
@@ -4,9 +4,9 @@
         "Name": "ubuntu-16.04",
         "Family": "ubuntu",
         "Version": "16.04",
-        "IsoFile": "ubuntu-16.04-server-amd64.iso",
-        "IsoUrl": "http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04-server-amd64.iso",
-        "IsoSha256": "b8b172cbdf04f5ff8adc8c2c1b4007ccf66f00fc6a324a6da6eba67de71746f6"
+        "IsoFile": "ubuntu-16.04.2-server-amd64.iso",
+        "IsoUrl": "http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.2-server-amd64.iso",
+        "IsoSha256": "737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535"
     },
     "Kernel": "install/netboot/ubuntu-installer/amd64/linux",
     "Initrds": [ "install/netboot/ubuntu-installer/amd64/initrd.gz" ],


### PR DESCRIPTION
16.04.2 was released on February 17th, 2017