### PR TITLE
Add profile ops to the rule-engine core

### DIFF
--- a/core/rails/app/models/barclamp.rb
+++ b/core/rails/app/models/barclamp.rb
@@ -293,6 +293,11 @@ class Barclamp < ActiveRecord::Base
                              schema: attrib_writable ? attrib['schema']: nil,
                              barclamp_id: barclamp.id)
       end if bc['attribs']
+      bc['profiles'].each do |profile|
+        Rails.logger.info("Importing profile #{profile['name']} for barclamp #{barclamp.name}")
+        p = Profile.find_or_create_by!(name: profile['name'])
+        p.update_attributes!(values: profile['values'])
+      end if bc['profiles']
       barclamp
     end
   end


### PR DESCRIPTION
This allows the rule engine and the classifier to set/append/remove
profiles from nodes.  I also added a convienence helper in the barclamp
import code to allow importing profiles.