### PR TITLE
Pull ISO information from Bootenv instead of hardcoded 

### DIFF
--- a/deploy/digitalrebar.yml
+++ b/deploy/digitalrebar.yml
@@ -1,6 +1,10 @@
 --- 
 - name: Install Digital Rebar by RackN 2015
   hosts: all
+  vars:
+    ubuntu_iso: "{{lookup('file','./compose/config-dir/provisioner/bootenvs/ubuntu-16.04.json')}}"
+    centos_iso: "{{lookup('file','./compose/config-dir/provisioner/bootenvs/centos-7.3.1611.json')}}"
+
   tasks:
     - include: tasks/base.yml
     - include: tasks/docker.yml

--- a/deploy/tasks/compose.yml
+++ b/deploy/tasks/compose.yml
@@ -64,11 +64,11 @@
     synchronize: src=./tftpboot dest={{home_dir.stdout}}/.cache/digitalrebar rsync_path="rsync"
     when: "'--provisioner' in dr_services and local_isos.stat.exists"
 
-  - name: download Ubuntu ISO (SLOW, see https://github.com/digitalrebar/digitalrebar/tree/master/deploy/containers/provisioner/update-nodes/bootenvs)
+  - name: "download {{ubuntu_iso.OS.IsoFile}} (SLOW from {{ubuntu_iso.OS.IsoUrl}})"
     get_url: url="{{ubuntu_iso.OS.IsoUrl}}" dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/{{ubuntu_iso.OS.IsoFile}}" checksum="sha256:{{ubuntu_iso.OS.IsoSha256}}"
     when: "'--provisioner' in dr_services and not local_isos.stat.exists"
 
-  - name: download Centos ISO (SLOW, see https://github.com/digitalrebar/digitalrebar/tree/master/deploy/containers/provisioner/update-nodes/bootenvs)
+  - name: "download {{centos_iso.OS.IsoFile}} (SLOW from {{centos_iso.OS.IsoUrl}})"
     get_url: url="{{centos_iso.OS.IsoUrl}}" dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/{{centos_iso.OS.IsoFile}}" checksum="sha256:{{centos_iso.OS.IsoSha256}}"
     when: "'--provisioner' in dr_services and not local_isos.stat.exists"
 

--- a/deploy/tasks/compose.yml
+++ b/deploy/tasks/compose.yml
@@ -65,11 +65,11 @@
     when: "'--provisioner' in dr_services and local_isos.stat.exists"
 
   - name: download Ubuntu ISO (SLOW, see https://github.com/digitalrebar/digitalrebar/tree/master/deploy/containers/provisioner/update-nodes/bootenvs)
-    get_url: url=http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.2-server-amd64.iso dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/ubuntu-16.04.1-server-amd64.iso" checksum="sha256:737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535"
+    get_url: url="{{ubuntu_iso.OS.IsoUrl}}" dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/{{ubuntu_iso.OS.IsoFile}}" checksum="sha256:{{ubuntu_iso.OS.IsoSha256}}"
     when: "'--provisioner' in dr_services and not local_isos.stat.exists"
 
   - name: download Centos ISO (SLOW, see https://github.com/digitalrebar/digitalrebar/tree/master/deploy/containers/provisioner/update-nodes/bootenvs)
-    get_url: url=http://mirrors.kernel.org/centos/7.3.1611/isos/x86_64/CentOS-7-x86_64-Minimal-1611.iso dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/CentOS-7-x86_64-Minimal-1511.iso" checksum="sha256:27bd866242ee058b7a5754e83d8ee8403e216b93d130d800852a96f41c34d86a"
+    get_url: url="{{centos_iso.OS.IsoUrl}}" dest="{{home_dir.stdout}}/.cache/digitalrebar/tftpboot/isos/{{centos_iso.OS.IsoFile}}" checksum="sha256:{{centos_iso.OS.IsoSha256}}"
     when: "'--provisioner' in dr_services and not local_isos.stat.exists"
 
   - name: Make code dirs


### PR DESCRIPTION
This change reduces the number of places where we have to track the URLs for ISOs since they change all the time.

We will still need to update for major version changes in the digitalrebar.yml