### PR TITLE
Add schema to bios-config-sets

### DIFF
--- a/core/barclamps/bios.yml
+++ b/core/barclamps/bios.yml
@@ -774,6 +774,24 @@ roles:
       - name: bios-config-sets
         map: 'bios/config_sets'
         description: 'The permitted BIOS configurations for this node.'
+        schema:
+          type: seq
+          sequence:
+            - type: map
+              mapping:
+                name:
+                  type: str
+                  required: true
+                parent:
+                  type: str
+                  required: false
+                settings:
+                  type: map
+                  required: true
+                  mapping:
+                    =:
+                      type: str
+
     wants-attribs:
       - provisioner-webservers
   - name: bios-configure


### PR DESCRIPTION
This allows the bios-config-sets attrib to be included in a profile,
making it easier to define custom BIOS settings that should be applied
across a block of systems.