### PR TITLE
issue #237 - needed to add ad-hoc items to openstack command line

### DIFF
--- a/core/rails/app/models/open_stack_provider.rb
+++ b/core/rails/app/models/open_stack_provider.rb
@@ -63,6 +63,18 @@ class OpenStackProvider < CloudProvider
         length: 30,
         name: I18n.t('os-region-name', scope: "providers.show.openstack" )
       },
+      :"os-user-domain-name" => {
+        type: "text",
+        default: "",
+        length: 30,
+        name: "User Domain Name"
+      },
+      :"os-identity-api-version" => {
+        type: "text",
+        default: "",
+        length: 5,
+        name: "Identity API version"
+      },
       :"os-ssh-user" => {
         type: "text",
         default: "centos ubuntu root",


### PR DESCRIPTION
This fixes the cloudwrap back end so that we can take new parameters without cloudwrap changes.

It will require the cloudwrap to be rebuilt.  The new params will be surfaced in the UI because of the model change.