### PR TITLE
Add trailing slashes to correctly sync RAID tools dir

### DIFF
--- a/deploy/tasks/compose.yml
+++ b/deploy/tasks/compose.yml
@@ -80,7 +80,7 @@
     when: "'--provisioner' in dr_services and cloud_type is not defined"
 
   - name: "push RAID/BIOS if in local ~/.cache/digitalrebar/tftpboot/files/raid"
-    synchronize: src=~/.cache/digitalrebar/tftpboot/files/raid dest={{home_dir.stdout}}/.cache/digitalrebar/tftpboot/files/raid rsync_path="rsync"
+    synchronize: src=~/.cache/digitalrebar/tftpboot/files/raid/ dest={{home_dir.stdout}}/.cache/digitalrebar/tftpboot/files/raid/ rsync_path="rsync"
     when: "'--provisioner' in dr_services and cloud_type is not defined"
 
   - local_action: stat path=~/.netrc


### PR DESCRIPTION
So, this is a minor change but it's to prevent this:
![duplicated RAID tool folder hierarchy](https://up.lae.is/i/1492719878-c76a5.png)