### PR TITLE
Address a couple of issues that are network related.

### DIFF
--- a/core/rails/app/models/network.rb
+++ b/core/rails/app/models/network.rb
@@ -99,7 +99,7 @@ class Network < ActiveRecord::Base
   def self.check_sanity(n)
     res = []
     # First, check the conduit to be sure it is sane.
-    intf_re =  /^bmc$|^dhcp$|^([-+?]?)(\d{1,3}[mg])(\d+)$/
+    intf_re =  /^raw:|^bmc$|^dhcp$|^([-+?]?)(\d{1,3}[mg])(\d+)$/
     if n.conduit.nil? || n.conduit.empty?
       res << [:conduit, "Conduit definition cannot be empty"]
       intfs = []


### PR DESCRIPTION
First, off-line mode works until you need cstruct gem.  We don't have
a way to cache it.  We do now.  It has been moved to the chef client
role since it already has that style and information.  The network
role doesn't try to install cstruct now.  It assumes chef-client role
put it in place.

Second, Add a new conduit option.  raw:interface
Instead of using the conduit maps to resolve the interface.  This allows
for a raw specification of the interface name, e.g. raw:ens4.
This will put the ip address assigned for this network on that
interface.  The raw: syntax functions with the bond and bridge code as
well.