### PR TITLE
Allow uuid to be set on node create.

### DIFF
--- a/core/rails/app/controllers/nodes_controller.rb
+++ b/core/rails/app/controllers/nodes_controller.rb
@@ -255,9 +255,10 @@ class NodesController < ApplicationController
       hints = params[:hints] || {}
       Rails.logger.info("Node create params: #{params.inspect}")
       @node = Node.create!(params.permit(:name,
+                                         :uuid,
                                          :description,
                                          :admin,
-					 :tenant_id,
+                                         :tenant_id,
                                          :deployment_id,
                                          :provider_id,
                                          :allocated,


### PR DESCRIPTION
This allows for DRP to create nodes with matching UUIDs as its Machines.