### PR TITLE
Add profiles support for deployments as well as nodes

### DIFF
--- a/core/rails/app/controllers/deployments_controller.rb
+++ b/core/rails/app/controllers/deployments_controller.rb
@@ -48,10 +48,10 @@ class DeploymentsController < ApplicationController
 
   def create
     Deployment.transaction do
-      permits = [:name,:parent_id,:description,:tenant_id]
+      permits = [:name,:parent_id,:description,:tenant_id,:profiles]
       if params[:system]
         raise "Only one system deployment permitted" if Deployment.exists?(system: true)
-        permits = [:name,:system,:description,:tenant_id]
+        permits = [:name,:system,:description,:tenant_id, :profiles]
       else
         if params[:parent] || params[:parent_id]
           # This should arguably be UPDATE
@@ -83,7 +83,7 @@ class DeploymentsController < ApplicationController
   def update
     Deployment.transaction do
       @deployment = find_key_cap(model,params[:id],cap("UPDATE")).lock!
-      simple_update(@deployment,%w{name description tenant_id}, %w{state})
+      simple_update(@deployment,%w{name description tenant_id profiles}, %w{state})
     end
     respond_to do |format|
       format.html { redirect_to deployment_path(@deployment.id) }

--- a/core/rails/app/models/barclamp_flash/discover.rb
+++ b/core/rails/app/models/barclamp_flash/discover.rb
@@ -17,9 +17,9 @@ class BarclampFlash::Discover < Role
 
   def do_transition(nr, data)
     unless Attrib.get("enable-flash-subsystem",nr.node)
-        update_runlog("Flash subsystem is not enabled. Skipping this function.")
-        update_runlog("Set enable-flash-subsystem to true and rerun role to start Flash processing.")
-        return
+      update_log("Flash subsystem is not enabled. Skipping this function.")
+      update_log("Set enable-flash-subsystem to true and rerun role to start Flash processing.")
+      return
     end
 
     update_log(nr, "Determining Flash System to use:")

--- a/core/rails/app/models/deployment_role.rb
+++ b/core/rails/app/models/deployment_role.rb
@@ -108,7 +108,9 @@ class DeploymentRole < ActiveRecord::Base
   end
 
   def all_committed_data
-    role.template.deep_merge(self.wall).deep_merge(self.committed_data)
+    from_attribs = role.attribs + role.wanted_attribs
+    profile_data = deployment.from_profiles(from_attribs)
+    role.template.deep_merge(profile_data).deep_merge(self.wall).deep_merge(self.committed_data)
   end
 
   def all_data(only_committed = false)

--- a/core/rails/app/models/role.rb
+++ b/core/rails/app/models/role.rb
@@ -237,7 +237,7 @@ class Role < ActiveRecord::Base
     Rails.logger.info("Role: Trying to add #{name} to #{node.name}")
     NodeRole.safe_create!(node_id:       node.id,
                           role_id:       id,
-			  tenant_id:     node.tenant_id,
+                          tenant_id:     node.tenant_id,
                           deployment_id: dep.id)
   end
 

--- a/core/rails/db/migrate/20170609084000_add_profiles_to_deployments.rb
+++ b/core/rails/db/migrate/20170609084000_add_profiles_to_deployments.rb
@@ -1,0 +1,26 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class AddProfilesToDeployments < ActiveRecord::Migration
+
+  def self.up
+    add_column :deployments, :profiles, :text, array: true, null: false, default: { expr: "ARRAY[]::text[]" }
+  end
+
+  def self.down
+    remove_column :deployments, :profiles
+  end
+
+end

--- a/go/rebar-api/datatypes/deployment.go
+++ b/go/rebar-api/datatypes/deployment.go
@@ -31,6 +31,8 @@ type Deployment struct {
 	ParentID null.Int `json:"parent_id"`
 	// The ID of the owning tenant
 	TenantID int64 `json:"tenant_id,omitempty"`
+	// The list of profiles that should be used to grab attrib information from
+	Profiles []string `json:"profiles"`
 }
 
 func (o *Deployment) ApiName() string {


### PR DESCRIPTION
The deployments model gains a profiles column along with equivalent functionality.
Deployment profiles have a higher precedence than defaults, and a lower precedence than
values set via a node-specific profiles.  Values in deployment profiles will be looked
up in the context of the node's current deployment, and values set via parent deployments
are also mixed in.