### PR TITLE
Shift around where we set provisioner-target_os.

### DIFF
--- a/core/barclamps/provisioner.yml
+++ b/core/barclamps/provisioner.yml
@@ -194,11 +194,6 @@ roles:
     jig: script
     icon: present_to_all
     events:
-      - endpoint: inproc://role:provisioner-os-install/on_deployment_create
-        selectors:
-          - event: on_deployment_create
-            obj_class: role
-            obj_id: provisioner-os-install
       - endpoint: inproc://role:provisioner-os-install/on_todo
         selectors:
           - event: on_todo

--- a/core/rails/app/models/barclamp_provisioner/os_install.rb
+++ b/core/rails/app/models/barclamp_provisioner/os_install.rb
@@ -15,14 +15,6 @@
 
 class BarclampProvisioner::OsInstall < Role
 
-  def on_deployment_create(dr)
-    DeploymentRole.transaction do
-      sysdepl = Deployment.system
-      default_os = Attrib.get('provisioner-default-os',sysdepl)
-      Attrib.set('provisioner-target_os', dr, default_os)
-    end
-  end
-
   def on_todo(nr)
     node = nr.node
     return if (["local"].member? node.bootenv) || (nr.run_count > 0)
@@ -44,6 +36,12 @@ class BarclampProvisioner::OsInstall < Role
         Attrib.set('claimed-disks',node,claims)
       end
       target_os = Attrib.get("provisioner-target_os",nr)
+      if target_os.nil? || target_os == ''
+        sysdepl = Deployment.system
+        default_os = Attrib.get('provisioner-default-os',sysdepl)
+        Attrib.set('provisioner-target_os', nr, default_os)
+        target_os = default_os
+      end
       Rails.logger.info("provisioner-install: Trying to install #{target_os} on #{node.name} (bootenv: #{node.bootenv})")
       node.bootenv = "#{target_os}-install"
       node.save!


### PR DESCRIPTION
We stop setting provisioner-target_os on the deployment role at bind
time, as that prevents us from picking the value up from a profile set
in a deployment.

Instead, set it on the node if and only if the node is not already
getting a value from somewhere else.