### PR TITLE
Allow leases and bindings in the same nework range.

### DIFF
--- a/core/rails/app/controllers/networks_controller.rb
+++ b/core/rails/app/controllers/networks_controller.rb
@@ -109,11 +109,11 @@ class NetworksController < ::ApplicationController
           # Legacy support for special "host" and "dhcp" range names
           case range_params[:name]
           when "host"
-            range_params[:allow_anon_leases] = false
-            range_params[:allow_bound_leases] = true
+            range_params[:allow_anon_leases] = false if range_params[:allow_anon_leases].nil?
+            range_params[:allow_bound_leases] = true if range_params[:allow_bound_leases].nil?
           when "dhcp"
-            range_params[:allow_anon_leases] = true
-            range_params[:allow_bound_leases] = false
+            range_params[:allow_anon_leases] = true if range_params[:allow_anon_leases].nil?
+            range_params[:allow_bound_leases] = false if range_params[:allow_bound_leases].nil?
           end
           if range_params[:anon_lease_time] && range_params[:anon_lease_time] == 0
             range_params[:anon_lease_time] = 60

--- a/core/rails/app/models/network_allocation.rb
+++ b/core/rails/app/models/network_allocation.rb
@@ -58,7 +58,7 @@ class NetworkAllocation < ActiveRecord::Base
     unless network_range === address
       errors.add("Allocation #{network.name}.#{network_range.name}.#{address.to_s} not in parent range!")
     end
-    errors.add("Allocation #{network_range.fullname}.#{address.to_s} cannot be bound because it is in a range set aside for anonymous leases!") if network_range.allow_anon_leases
+    errors.add("Allocation #{network_range.fullname}.#{address.to_s} cannot be bound because it is in a range set aside for anonymous leases!") unless network_range.allow_bound_leases
   end
 
   def on_destroy_hooks

--- a/core/rails/app/models/network_range.rb
+++ b/core/rails/app/models/network_range.rb
@@ -188,8 +188,6 @@ class NetworkRange < ActiveRecord::Base
 
     errors.add(:bound_lease_time, "NetworkRange #{fullname} must have a bound lease time at least 3 times greater than its anonymous lease time") unless bound_lease_time >= (anon_lease_time * 3)
 
-    errors.add(:allow_anon_leases, "NetworkRange #{fullname} must allow either anonymous leases or bound leases, but not both.") if allow_anon_leases && allow_bound_leases
-
     errors.add(:network, "NetworkRange #{fullname}: must have a non-configure parent network with specifying overlap") if (overlap and network and network.configure)
 
     unless first.subnet == last.subnet

--- a/deploy/compose/config-dir/api/config/networks/the_admin.json.forwarder
+++ b/deploy/compose/config-dir/api/config/networks/the_admin.json.forwarder
@@ -10,6 +10,7 @@
       "first": "192.168.124.81/24",
       "last": "192.168.124.128/24",
       "allow_anon_leases": true,
+      "allow_bound_leases": true,
       "anon_lease_time": 3600
     }
   ],


### PR DESCRIPTION
This change allows Rebar to hand out both short-term leases and bind
reservations from the same network range.  The use case is where Rebar
is managing DHCP for a subnet that is expected to be completly
populated (hence we cannot set aside a pool of addresses for initial
system discovery), and so we will need to arrange to allocate the
addresses a system used for initial discovery to that system on a
long-term basis.

Sledgehammer has also been updated to pass all of the MAC addresses
for discovered Ethernet devices at node create time, instead of just
the MAC that the system happened to boot from.  This gets rid of
spurious node creation when (due to forces beyond our control) the
system PXE boots from a different nic during the provision process.