### PR TITLE
Bump Ubuntu releases to 16.04.3

### DIFF
--- a/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-16.04.json
+++ b/deploy/compose/config-dir/provisioner/bootenvs/ubuntu-16.04.json
@@ -5,9 +5,9 @@
         "Name": "ubuntu-16.04",
         "Family": "ubuntu",
         "Version": "16.04",
-        "IsoFile": "ubuntu-16.04.2-server-amd64.iso",
-        "IsoUrl": "http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.2-server-amd64.iso",
-        "IsoSha256": "737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535"
+        "IsoFile": "ubuntu-16.04.3-server-amd64.iso",
+        "IsoUrl": "http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.3-server-amd64.iso",
+        "IsoSha256": "a06cd926f5855d4f21fb4bc9978a35312f815fbda0d0ef7fdc846861f4fc4600"
     },
     "Kernel": "install/netboot/ubuntu-installer/amd64/linux",
     "Initrds": [ "install/netboot/ubuntu-installer/amd64/initrd.gz" ],

--- a/go/provisioner-mgmt/bootenvs/ubuntu-16.04.json
+++ b/go/provisioner-mgmt/bootenvs/ubuntu-16.04.json
@@ -4,9 +4,9 @@
         "Name": "ubuntu-16.04",
         "Family": "ubuntu",
         "Version": "16.04",
-        "IsoFile": "ubuntu-16.04.2-server-amd64.iso",
-        "IsoUrl": "http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.2-server-amd64.iso",
-        "IsoSha256": "737ae7041212c628de5751d15c3016058b0e833fdc32e7420209b76ca3d0a535"
+        "IsoFile": "ubuntu-16.04.3-server-amd64.iso",
+        "IsoUrl": "http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.3-server-amd64.iso",
+        "IsoSha256": "a06cd926f5855d4f21fb4bc9978a35312f815fbda0d0ef7fdc846861f4fc4600"
     },
     "Kernel": "install/netboot/ubuntu-installer/amd64/linux",
     "Initrds": [ "install/netboot/ubuntu-installer/amd64/initrd.gz" ],


### PR DESCRIPTION
Canonical in their infinite wisdom seems to only ship the most recent
ISOs at their well known URLs and thus on mirrors now.

Potential fix for #306 

It's also possible you may want to use the official distribution URL of http://releases.ubuntu.com/16.04.3/ubuntu-16.04.3-server-amd64.iso to take some load off mirrors.kernel.org