### PR TITLE
Do not change node aliveness when it is not available.

### DIFF
--- a/core/rails/app/models/secure_shell_hammer.rb
+++ b/core/rails/app/models/secure_shell_hammer.rb
@@ -51,7 +51,7 @@ class SecureShellHammer < Hammer
 
   # and it only allows you to reboot a node via its "reboot" command
   def reboot
-    node.update!(alive: false)
+    node.update!(alive: false) if node.available
     run("reboot")
   end
 

--- a/deploy/compose/config-dir/provisioner/templates/rebar-join.sh.tmpl
+++ b/deploy/compose/config-dir/provisioner/templates/rebar-join.sh.tmpl
@@ -53,6 +53,11 @@ fi
 export REBAR_ENDPOINT="{{.CommandURL}}"
 echo "{{.CommandURL}}" > /etc/rebar.endpoint
 
+if [[ $(rebar nodes show $REBAR_UUID |jq -r '.available') != true ]]; then
+    echo "Node not available, doing nothing"
+    exit 0
+fi
+
 put_alive() {
     echo "Setting node alive=$1"
     rebar nodes update "$REBAR_UUID" "{\"alive\": $1, \"bootenv\": \"local\"}"
@@ -61,7 +66,7 @@ put_alive() {
     done
 }
 
-# Force time (some OS already have this done)q
+# Force time (some OS already have this done)
 ntpdate "{{index (.Param "ntp_servers") 0}}" 2>/dev/null >/dev/null
 
 case $1 in


### PR DESCRIPTION
Update the rebar_join script and the SSH jig reboot command to
leave node aliveness alone if the node is not available.

This leaves the noderole states alone when we do not want them to change
across a reboot.